### PR TITLE
parse multiple alleles into distinct Variant records

### DIFF
--- a/test/data/multiallelic.vcf
+++ b/test/data/multiallelic.vcf
@@ -1,0 +1,16 @@
+##fileformat=VCFv4.1
+##reference=file:///projects/ngs/resources/gatk/2.3/ucsc.hg19.fasta
+##INFO=<ID=GE,Number=.,Type=String,Description="HGNC Gene Symbol (could be more than one)">
+##INFO=<ID=DP,Number=.,Type=Integer,Description="Depth">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chrM,length=16571>
+##contig=<ID=chr1,length=249250621>
+##contig=<ID=chr10,length=135534747>
+##contig=<ID=chr11,length=135006516>
+##contig=<ID=chr12,length=133851895>
+##contig=<ID=chr14,length=107349540>
+##contig=<ID=chr15,length=102531392>
+##contig=<ID=chr16,length=90354753>
+##contig=<ID=chr17,length=81195210>
+#CHROM  POS ID  REF ALT QUAL    FILTER  INFO    FORMAT  metastasis
+chr1    1431105 rs199599542     A       C,G     593.69  PASS DP=17;GE=Wuzzle     GT     0/1

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from varcode import load_vcf
+from nose.tools import eq_
+from varcode import load_vcf, Variant
 
 VCF_FILENAME = "data/somatic_hg19_14muts.vcf"
 
@@ -37,3 +38,14 @@ def test_vcf_gene_names():
     variants = load_vcf(VCF_FILENAME)
     for variant in variants:
         yield (_check_variant_gene_name, variant)
+
+def test_multiple_alleles_per_line():
+    variants = load_vcf("data/multiallelic.vcf")
+    assert len(variants) == 2, "Expected 2 variants but got %s" % variants
+    variant_list = list(variants)
+    ensembl = variant_list[0].ensembl
+    expected_variants = [
+        Variant(1, 1431105, "A", "C", ensembl=ensembl),
+        Variant(1, 1431105, "A", "G", ensembl=ensembl),
+    ]
+    eq_(variant_list, expected_variants)

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -15,6 +15,7 @@
 from __future__ import print_function, division, absolute_import
 import logging
 
+from Bio.Seq import reverse_complement
 from pyensembl import Transcript, find_nearest_locus, EnsemblRelease
 from pyensembl.locus import normalize_chromosome
 from pyensembl.biotypes import is_coding_biotype
@@ -23,7 +24,7 @@ from typechecks import require_instance
 from .coding_effect import infer_coding_effect
 from .common import group_by
 from .nucleotides import normalize_nucleotide_string
-from .string_helpers import reverse_complement, trim_shared_flanking_strings
+from .string_helpers import trim_shared_flanking_strings
 from .transcript_helpers import interval_offset_on_transcript
 from .effects import (
     NoncodingTranscript,


### PR DESCRIPTION
Fixes https://github.com/hammerlab/varcode/issues/22.

Also fixes bug from the last PEP8 PR which removed `reverse_complement` from `string_helpers`. 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/29)
<!-- Reviewable:end -->
