### PR TITLE
Typechecks and test fixes

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,12 @@
+'''
+Utility functions for tests.
+'''
+
+import os
+
+def data_path(name):
+    '''
+    Return the absolute path to a file in the varcode/test/data directory.
+    The name specified should be relative to varcode/test/data.
+    '''
+    return os.path.join(os.path.dirname(__file__), "data", name)

--- a/test/test_dbnsfp_validation.py
+++ b/test/test_dbnsfp_validation.py
@@ -15,6 +15,7 @@
 import pandas as pd
 from pyensembl import EnsemblRelease
 from varcode import Substitution, Variant
+from . import data_path
 
 ensembl = EnsemblRelease(75)
 
@@ -49,7 +50,7 @@ def test_dbnsfp_validation_set():
     # - ensembl_transcript : transcript ID
     # - dna_position : base-1 position within chromosome
     # - dna_ref : reference DNA nucleotide
-    validation_set = pd.read_csv('data/dbnsfp_validation_set.csv')
+    validation_set = pd.read_csv(data_path('dbnsfp_validation_set.csv'))
     for _, row in validation_set.iterrows():
         args = (
             row['ensembl_transcript'],

--- a/test/test_maf.py
+++ b/test/test_maf.py
@@ -11,14 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
 from nose.tools import eq_
 from pyensembl import EnsemblRelease
 from varcode import load_maf, Variant
+from . import data_path
 
 def test_maf():
     ensembl = EnsemblRelease(75)
-    variant_collection_from_maf = load_maf("data/tcga_ov.head.maf")
+    variant_collection_from_maf = load_maf(data_path("tcga_ov.head.maf"))
     expected_variants = [
         Variant(1, 1650797, "A", "G", ensembl),
         Variant(1, 23836447, "C", "A", ensembl),

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -14,8 +14,9 @@
 
 from nose.tools import eq_
 from varcode import load_vcf, Variant
+from . import data_path
 
-VCF_FILENAME = "data/somatic_hg19_14muts.vcf"
+VCF_FILENAME = data_path("somatic_hg19_14muts.vcf")
 
 def test_vcf_reference_name():
     variants = load_vcf(VCF_FILENAME)
@@ -40,7 +41,7 @@ def test_vcf_gene_names():
         yield (_check_variant_gene_name, variant)
 
 def test_multiple_alleles_per_line():
-    variants = load_vcf("data/multiallelic.vcf")
+    variants = load_vcf(data_path("multiallelic.vcf"))
     assert len(variants) == 2, "Expected 2 variants but got %s" % variants
     variant_list = list(variants)
     ensembl = variant_list[0].ensembl
@@ -48,4 +49,4 @@ def test_multiple_alleles_per_line():
         Variant(1, 1431105, "A", "C", ensembl=ensembl),
         Variant(1, 1431105, "A", "G", ensembl=ensembl),
     ]
-    eq_(variant_list, expected_variants)
+    eq_(set(variant_list), set(expected_variants))

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyensembl import type_checks
 from .effects import *
 from .effect_ordering import effect_priority, top_priority_transcript_effect
 from .maf import load_maf, load_maf_dataframe

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -15,6 +15,7 @@
 # required so that 'import vcf' gets the global PyVCF package,
 # rather than our local vcf module
 from __future__ import absolute_import
+import typechecks
 
 from .reference_name import (
     infer_reference_name,
@@ -22,7 +23,6 @@ from .reference_name import (
 )
 from .variant import Variant
 from .variant_collection import VariantCollection
-from . import type_checks
 from pyensembl import EnsemblRelease
 
 import vcf  # PyVCF
@@ -53,7 +53,7 @@ def load_vcf(
         from the reference path.
     """
 
-    type_checks.require_string(filename, "filename")
+    typechecks.require_string(filename, "filename")
 
     vcf_reader = vcf.Reader(filename=filename)
 


### PR DESCRIPTION
 * Replace reference to pyensembl type_checks module with typechecks package
 * Fix nondeterministic test failure in test_vcf.py
 * Add test utility module (`__init__.py` in the test directory) with `data_path` function for getting the absolute path to test resources
 * Modify tests to use `data_path`, instead of assuming that the current working directory is the 'test' directory. This makes it possible to run `nosetests` either in the root `varcode` directory or in the `test` directory.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/35)
<!-- Reviewable:end -->
