### PR TITLE
Test problematic variants

### DIFF
--- a/test/test_cosmic_mutations.py
+++ b/test/test_cosmic_mutations.py
@@ -64,8 +64,13 @@ def _insertion(chrom, pos, dna_ref, dna_alt, transcript_id, inserted):
     assert isinstance(effect, Insertion), \
         "Expected insertion, got %s" % (effect,)
     assert effect.aa_alt == inserted, \
-        "Expected insertion of '%s' but got '%s' for %s:%d%s>%s" % (
-            inserted, effect.aa_alt, chrom, pos, dna_ref, dna_alt)
+        "Expected insertion of '%s' but got %s for %s:%d%s>%s" % (
+            inserted,
+            effect.short_description(),
+            chrom,
+            pos,
+            dna_ref,
+            dna_alt)
 
 def _frameshift(
         chrom, pos, dna_ref, dna_alt, transcript_id,

--- a/test/test_maf.py
+++ b/test/test_maf.py
@@ -56,7 +56,7 @@ def test_maf_aa_changes():
 
     expected_changes = {}
     maf_fields = pd.read_csv(
-        "data/ov.wustle.subset5.maf",
+        data_path("ov.wustle.subset5.maf"),
         sep="\t",
         comment="#")
     for _, row in maf_fields.iterrows():

--- a/test/test_maf.py
+++ b/test/test_maf.py
@@ -70,6 +70,6 @@ def test_maf_aa_changes():
             expected_changes[key] = change
 
     for variant in variants:
-        key = (variant.contig, variant.pos)
+        key = (variant.contig, variant.start)
         expected = expected_changes[key]
         yield (check_same_aa_change, variant, expected)

--- a/test/test_mutate.py
+++ b/test/test_mutate.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from varcode import mutate
+from nose.tools import eq_
+
+def test_snp_mutation():
+    seq = "AACCTT"
+    mutated = mutate.substitute(seq, 1, "A", "G")
+    eq_(mutated, "AGCCTT")
+
+def test_deletion_mutation():
+    seq = "AACT"
+    mutated = mutate.substitute(seq, 1, "ACT", "T")
+    eq_(mutated, "AT")
+
+def test_insert_before():
+    mutated = mutate.insert_before("AACT", 1, "GG")
+    eq_(mutated, "AGGACT")
+
+def test_insert_after():
+    mutated = mutate.insert_after("AACT", 1, "GG")
+    eq_(mutated, "AAGGCT")

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -1,0 +1,48 @@
+"""
+Any variants which are encountered in the wild and either cause Varcode
+to crash or return an incorrect annotation should be added to this
+test module.
+"""
+
+from pyensembl import EnsemblRelease
+from varcode import Variant
+
+ensembl75 = EnsemblRelease(75)
+
+# variants which have previously resulted in raised exceptions
+# during effect annotation
+should_not_crash_variants = [
+    # error message:
+    # "Couldn't find position 92979124 on any exon of ENST00000540033"
+    Variant(
+        contig=1,
+        pos=92979092,
+        ref="ATATATATATATATATATATATATATATATATG",
+        alt="A",
+        ensembl=ensembl75),
+    # error message:
+    # "Expect non-silent stop-loss variant to cause longer variant protein"
+    # "" but got len(original) = 653, len(variant) = 653"
+    Variant(
+        contig=1,
+        pos=167385324,
+        ref="TAA",
+        alt="T",
+        ensembl=ensembl75),
+    # error message:
+    # "Variant which span 5' UTR and CDS not supported"
+    Variant(
+        contig=19,
+        pos=44351166,
+        ref="GGGAGAT",
+        alt="G",
+        ensembl=ensembl75)
+]
+
+def try_effect_annotation(variant):
+    effect = variant.top_effect()
+    assert effect is not None
+
+def test_crashing_variants():
+    for variant in should_not_crash_variants:
+        yield (try_effect_annotation, variant)

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -45,6 +45,30 @@ should_not_crash_variants = [
         ref="",
         alt="CCT",
         ensembl=ensembl75),
+    Variant(
+        contig=11,
+        start=47640416,
+        ref="",
+        alt="TCTTT",
+        ensembl=ensembl75),
+    Variant(
+        contig=12,
+        start=98880902,
+        ref="A",
+        alt="",
+        ensembl=ensembl75),
+    Variant(
+        contig=19,
+        start=52803670,
+        ref="TG",
+        alt="",
+        ensembl=ensembl75),
+    Variant(
+        contig=1,
+        start=109792735,
+        ref="",
+        alt="CGC",
+        ensembl=ensembl75)
 ]
 
 def try_effect_annotation(variant):

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -16,7 +16,7 @@ should_not_crash_variants = [
     # "Couldn't find position 92979124 on any exon of ENST00000540033"
     Variant(
         contig=1,
-        pos=92979092,
+        start=92979092,
         ref="ATATATATATATATATATATATATATATATATG",
         alt="A",
         ensembl=ensembl75),
@@ -25,7 +25,7 @@ should_not_crash_variants = [
     # "" but got len(original) = 653, len(variant) = 653"
     Variant(
         contig=1,
-        pos=167385324,
+        start=167385324,
         ref="TAA",
         alt="T",
         ensembl=ensembl75),
@@ -33,10 +33,18 @@ should_not_crash_variants = [
     # "Variant which span 5' UTR and CDS not supported"
     Variant(
         contig=19,
-        pos=44351166,
+        start=44351166,
         ref="GGGAGAT",
         alt="G",
-        ensembl=ensembl75)
+        ensembl=ensembl75),
+    # error message:
+    # "Can't have ref = '' and alt = 'E' at aa_pos = 445, cds_pos = 1335"
+    Variant(
+        contig=1,
+        start=1684347,
+        ref="",
+        alt="CCT",
+        genome=ensembl75),
 ]
 
 def try_effect_annotation(variant):

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -68,7 +68,15 @@ should_not_crash_variants = [
         start=109792735,
         ref="",
         alt="CGC",
-        ensembl=ensembl75)
+        ensembl=ensembl75),
+    # error message:
+    # "expected ref 'GATGTCGG' at offset 1412 of ENST00000297524...CDS has 'G'"
+    Variant(
+        contig=8,
+        start=87226635,
+        ref="CCGACATC",
+        alt="",
+        ensembl=ensembl75),
 ]
 
 def try_effect_annotation(variant):

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -44,7 +44,7 @@ should_not_crash_variants = [
         start=1684347,
         ref="",
         alt="CCT",
-        genome=ensembl75),
+        ensembl=ensembl75),
 ]
 
 def try_effect_annotation(variant):

--- a/test/test_timings.py
+++ b/test/test_timings.py
@@ -23,7 +23,7 @@ def test_effect_timing():
     variants = random_variants(n_variants)
     variant_collection = VariantCollection(variants)
     start_t = time.time()
-    effects = variant_collection.variant_effects()
+    effects = variant_collection.effects()
     assert len(effects) == len(variants)
     end_t = time.time()
     elapsed_t = end_t - start_t

--- a/test/test_timings.py
+++ b/test/test_timings.py
@@ -15,18 +15,20 @@
 from __future__ import print_function, division, absolute_import
 import time
 
-from varcode import VariantCollection
 from varcode.util import random_variants
 
-def test_effect_timing():
-    n_variants = 100
-    variants = random_variants(n_variants)
-    variant_collection = VariantCollection(variants)
+def _time_variant_annotation(variant_collection):
     start_t = time.time()
     effects = variant_collection.effects()
-    assert len(effects) == len(variants)
+    assert len(effects) == len(variant_collection)
     end_t = time.time()
     elapsed_t = end_t - start_t
+    return elapsed_t
+
+
+def test_effect_timing(n_variants=100):
+    variant_collection = random_variants(n_variants)
+    elapsed_t = _time_variant_annotation(variant_collection)
     print("Elapsed: %0.4f for %d variants" % (elapsed_t, n_variants))
     assert elapsed_t / n_variants < 1.0, \
         "Should be faster than 1 sec / variant!"

--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test simple properties of Variant objects, such as their trimming
+of shared prefix/suffix strings from ref/alt fields.
+"""
+
+from varcode import Variant
+from nose.tools import eq_
+
+def test_insertion_shared_prefix():
+    variant = Variant(1, start=10, ref="AA", alt="AAT")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "AA")
+    eq_(variant.original_alt, "AAT")
+    eq_(variant.original_start, 10)
+    # since this variant is just an insertion of a "T", get rid of
+    # the prefix context
+    eq_(variant.ref, "")
+    eq_(variant.alt, "T")
+    # the [start,end] interval for an insertion is just the base we're
+    # inserting after, which in this case is the 11th position
+    eq_(variant.start, 11)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.11_12insT")
+
+def test_insertion_no_prefix():
+    variant = Variant(1, start=11, ref="", alt="T")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "")
+    eq_(variant.original_alt, "T")
+    eq_(variant.original_start, 11)
+    eq_(variant.ref, "")
+    eq_(variant.alt, "T")
+    eq_(variant.start, 11)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.11_12insT")
+
+def test_substitution_no_prefix():
+    variant = Variant(1, start=11, ref="A", alt="T")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "A")
+    eq_(variant.original_alt, "T")
+    eq_(variant.original_start, 11)
+    eq_(variant.ref, "A")
+    eq_(variant.alt, "T")
+    eq_(variant.start, 11)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.11A>T")
+
+
+def test_substitution_shared_prefix():
+    variant = Variant(1, start=10, ref="AA", alt="AT")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "AA")
+    eq_(variant.original_alt, "AT")
+    eq_(variant.original_start, 10)
+    eq_(variant.ref, "A")
+    eq_(variant.alt, "T")
+    eq_(variant.start, 11)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.11A>T")
+
+
+def test_deletion_shared_suffix():
+    variant = Variant(1, start=10, ref="AAC", alt="C")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "AAC")
+    eq_(variant.original_alt, "C")
+    eq_(variant.original_start, 10)
+    eq_(variant.ref, "AA")
+    eq_(variant.alt, "")
+    eq_(variant.start, 10)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.10_11delAA")
+
+
+def test_deletion_no_suffix():
+    variant = Variant(1, start=10, ref="AA", alt="")
+    eq_(variant.contig, "1")
+    eq_(variant.original_ref, "AA")
+    eq_(variant.original_alt, "")
+    eq_(variant.original_start, 10)
+    eq_(variant.ref, "AA")
+    eq_(variant.alt, "")
+    eq_(variant.start, 10)
+    eq_(variant.end, 11)
+    eq_(variant.short_description(), "chr1 g.10_11delAA")

--- a/test/test_variant_collection.py
+++ b/test/test_variant_collection.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test properties of VariantCollection objects other than effect annotations
+"""
+from collections import Counter
+from nose.tools import eq_
+from varcode import load_maf
+
+from . import data_path
+
+def test_reference_names():
+    variants = load_maf(data_path("ov.wustle.subset5.maf"))
+    eq_(variants.reference_names(), {'GRCh37'})
+
+def test_summary_string():
+    variants = load_maf(data_path("ov.wustle.subset5.maf"))
+    summary_string = variants.summary_string()
+    # expect one of the gene names from the MAF to be in the summary string
+    assert "UBE4B" in summary_string, \
+        "Expected gene name UBE4B in summary_string():\n%s" % summary_string
+    assert "start=10238758, ref=G, alt=C" in summary_string, \
+        "Expected variant g.10238758 G>C in summary_string():\n%s" % (
+            summary_string,)
+
+def test_gene_counts():
+    variants = load_maf(data_path("tcga_ov.head.maf"))
+    expected_coding_gene_counts = Counter()
+    expected_coding_gene_counts["CDK11A"] = 1
+    expected_coding_gene_counts["GNPAT"] = 1
+    expected_coding_gene_counts["E2F2"] = 1
+    expected_coding_gene_counts["VSIG2"] = 1
+    all_gene_counts = variants.gene_counts()
+    assert len(all_gene_counts) > len(expected_coding_gene_counts), \
+        ("Gene counts for all genes must contain more elements than"
+         " gene counts for only coding genes.")
+    for (gene_name, count) in expected_coding_gene_counts.items():
+        eq_(count, all_gene_counts[gene_name])
+
+    # TODO: add `only_coding` parameter to gene_counts and then test
+    # for exact equality between `coding_gene_counts` and
+    # `expected_counts`
+    #
+    # coding_gene_counts = variants.gene_counts(only_coding=True)
+    # eq_(coding_gene_counts, expected_counts)

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .effects import *
-from .effect_ordering import effect_priority, top_priority_transcript_effect
+from .effect_ordering import effect_priority, top_priority_effect
 from .maf import load_maf, load_maf_dataframe
 from .variant import Variant
 from .variant_collection import VariantCollection

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -60,6 +60,7 @@ def infer_coding_effect(
 
     variant : Variant
     """
+
     if not transcript.complete:
         raise ValueError(
             ("Can't annotate coding effect for %s"
@@ -195,9 +196,8 @@ def infer_coding_effect(
                 aa_pos, variant,
                 transcript))
         return StartLoss(
-            variant,
-            transcript,
-            aa_pos=aa_pos,
+            variant=variant,
+            transcript=transcript,
             aa_alt=variant_protein[0])
 
     variant_stop_codon_index = variant_protein.find("*")
@@ -309,7 +309,6 @@ def infer_coding_effect(
             "Can't have empty ref and alt for variant %s on transcript %s" % (
                 variant, transcript)
         inserted = aa_alt[len(aa_ref):]
-
         return Insertion(
             variant, transcript,
             aa_pos=aa_pos,

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -60,7 +60,6 @@ def infer_coding_effect(
 
     variant : Variant
     """
-
     if not transcript.complete:
         raise ValueError(
             ("Can't annotate coding effect for %s"
@@ -304,11 +303,17 @@ def infer_coding_effect(
             aa_ref=deleted)
 
     # Insertion, e.g. p.37insA
-    elif aa_alt.startswith(aa_ref):
-        assert len(aa_alt) > 0, \
+    elif len(aa_ref) == 0:
+        assert len(aa_alt) > 1, \
             "Can't have empty ref and alt for variant %s on transcript %s" % (
                 variant, transcript)
-        inserted = aa_alt[len(aa_ref):]
+        # the meaning of positions for insertions is different, the inserted
+        # amino acids get put *after* aa_pos, so the first element of the
+        # aa_alt string is actually the ref nucleotide before the insertion
+        #
+        # TODO: what happens if we're inserting at the very beginning of
+        # a protein?
+        inserted = aa_alt[1:]
         return Insertion(
             variant, transcript,
             aa_pos=aa_pos,

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -82,7 +82,6 @@ def infer_coding_effect(
     else:
         cds_offset = transcript_offset - cds_start_offset
 
-    logging.info("%s offset = %d, cds offset = %d, strand = %s", variant, transcript_offset, cds_offset, transcript.strand)
     assert cds_offset < len(cds_seq), \
         "Expected CDS offset (%d) < |CDS| (%d) for %s on %s" % (
             cds_offset, len(cds_seq), variant, transcript)

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -184,9 +184,9 @@ def infer_coding_effect(
         # of the new protein sequence
         if len(variant_protein) == len(original_protein):
             logging.info(
-                "Expect non-silent stop-loss variant to cause longer variant "
-                "protein but got len(original) = %d, len(variant) = %d, "
-                "transcript %s probably lacks 3' UTR" % (
+                "Expected non-silent stop-loss variant to cause longer "
+                "protein but got len(original) = len(variant) = %d for "
+                "%s, transcript probably lacks 3' UTR" % (
                     len(original_protein),
                     len(variant_protein),
                     transcript))

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -289,11 +289,11 @@ def infer_coding_effect(
             "len(aa_alt) = 0 for variant %s on transcript %s (aa_pos=%d:%d)" % (
                 variant, transcript, aa_pos, last_aa_ref_pos)
 
-    if aa_alt == aa_ref:
+    if len(original_protein) == len(variant_protein) and aa_alt == aa_ref:
         raise ValueError(
             ("Unexpected silent mutation for variant %s "
-             " on transcript %s (aa=%s)" % (
-                 variant, transcript, aa_ref)))
+             " on transcript %s (aa='%s', aa_pos=%d)" % (
+                 variant, transcript, aa_ref, aa_pos)))
 
     # in case of simple insertion like FY>FYGL or deletions FYGL > FY,
     # get rid of the shared prefixes/suffixes
@@ -303,10 +303,7 @@ def infer_coding_effect(
     aa_pos += len(prefix)
 
     if frameshift:
-        if len(aa_ref) == 0:
-            assert len(prefix) > 0
-            aa_ref = prefix[-1]
-
+        aa_ref = original_protein[aa_pos]
         # if a frameshift doesn't create any new amino acids, then
         # it must immediately have hit a stop codon
         if len(aa_alt) == 0:

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -147,7 +147,7 @@ def infer_coding_effect(
         # TODO: use the full transcript.sequence instead of just
         # transcript.coding_sequence to get more than just one amino acid
         # of the new protein sequence
-        if len(variant_protein) <= len(original_protein):
+        if len(variant_protein) == len(original_protein):
             logging.info(
                 "Expect non-silent stop-loss variant to cause longer variant "
                 "protein but got len(original) = %d, len(variant) = %d, "

--- a/varcode/common.py
+++ b/varcode/common.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-
 from collections import defaultdict
+from functools import wraps
 
 def groupby_field(records, field_name):
     """
@@ -38,6 +38,7 @@ def memoize(fn):
     """
     memoized_values = {}
 
+    @wraps(fn)
     def wrapped_fn(*args, **kwargs):
         key = (args, tuple(sorted(kwargs.items())))
         if key not in memoized_values:

--- a/varcode/effect_ordering.py
+++ b/varcode/effect_ordering.py
@@ -68,7 +68,7 @@ def effect_priority(effect):
         return -1
     return transcript_effect_priority_dict[effect.__class__]
 
-def top_priority_transcript_effect(effects):
+def top_priority_effect(effects):
     """
     Given a collection of variant transcript effects,
     return the top priority object. In case of multiple transcript
@@ -88,10 +88,11 @@ def top_priority_transcript_effect(effects):
         elif priority == best_priority:
             best_effects.append(effect)
 
-    if any(effect.transcript.complete for effect in best_effects):
-        # if any transcripts have complete coding sequence annotations,
-        # filter the effects down to those that are complete and sort
-        # them by length of the coding sequence
+    if any(hasattr(effect, 'transcript') and
+           effect.transcript.complete for effect in best_effects):
+        # if any of the effects are trancript effects which have complete
+        # coding sequence annotations, filter the effects down to those that
+        # are complete and sort them by length of the coding sequence
         best_effects = [
             effect
             for effect in best_effects

--- a/varcode/effect_ordering.py
+++ b/varcode/effect_ordering.py
@@ -15,6 +15,7 @@
 from .effects import *
 
 transcript_effect_priority_list = [
+    Failure,
     Intergenic,
     Intragenic,
     IncompleteTranscript,

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -215,6 +215,23 @@ class Exonic(TranscriptMutationEffect):
     """
     pass
 
+class ExonLoss(Exonic):
+    """
+    Deletion of one or more exons in a transcript.
+    """
+    def __init__(self, variant, transcript, exons):
+        Exonic.__init__(self, variant, transcript)
+        self.exons = exons
+
+    def __str__(self):
+        return "ExonLoss(%s, %s, %s)" % (
+            self.variant,
+            self.transcript,
+            "+".join(self.exons))
+
+    def short_description(self):
+        return "exon-loss"
+
 class ExonicSpliceSite(Exonic, SpliceSite):
     """
     Mutation in the last three nucleotides before an intron
@@ -440,6 +457,9 @@ class UnpredictableCodingMutation(BaseSubstitution):
     an alternative Kozak consensus sequence (either before or after the
     original) from which an alternative start codon can be inferred.
     """
+    def __init__(self, variant, transcript, aa_pos, aa_ref, aa_alt):
+        BaseSubstitution.__init__(
+            self, variant, transcript, aa_pos, aa_ref, aa_alt)
 
     @property
     def mutant_protein_sequence(self):
@@ -454,8 +474,8 @@ class StartLoss(UnpredictableCodingMutation):
             aa_alt="?"):
         UnpredictableCodingMutation.__init__(
             self,
-            variant,
-            transcript,
+            variant=variant,
+            transcript=transcript,
             aa_pos=0,
             aa_ref="M",
             aa_alt=aa_alt)

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -131,6 +131,11 @@ class TranscriptMutationEffect(MutationEffect):
         return self.transcript.gene_id
 
 
+class Failure(TranscriptMutationEffect):
+    """Special placeholder effect for when we want to suppress errors but still
+    need to create a non-empty list of effects for each variant.
+    """
+
 class NoncodingTranscript(TranscriptMutationEffect):
     """
     Any mutation to a transcript with a non-coding biotype

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -451,13 +451,12 @@ class StartLoss(UnpredictableCodingMutation):
             self,
             variant,
             transcript,
-            aa_pos,
-            aa_alt):
+            aa_alt="?"):
         UnpredictableCodingMutation.__init__(
             self,
             variant,
             transcript,
-            aa_pos=aa_pos,
+            aa_pos=0,
             aa_ref="M",
             aa_alt=aa_alt)
 

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -522,8 +522,18 @@ class FrameShiftTruncation(PrematureStop, FrameShift):
     """
     A frame-shift mutation which immediately introduces a stop codon.
     """
-    def __init__(self, *args, **kwargs):
-        super(PrematureStop, self).__init__(*args, **kwargs)
+    def __init__(
+            self,
+            variant,
+            transcript,
+            aa_pos,
+            aa_ref):
+        PrematureStop.__init__(
+            self,
+            variant=variant,
+            transcript=transcript,
+            aa_pos=aa_pos,
+            aa_ref=aa_ref)
 
     @memoized_property
     def mutant_protein_sequence(self):

--- a/varcode/mutate.py
+++ b/varcode/mutate.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+
+def mutate(sequence, position, variant_ref, variant_alt):
+    """
+    Mutate a sequence by substituting given `alt` at instead of `ref` at the
+    given `position`.
+
+    Parameters
+    ----------
+    sequence : sequence
+        String of amino acids or DNA bases
+
+    position : int
+        Position in the sequence, starts from 0
+
+    variant_ref : sequence or str
+        What do we expect to find at the position?
+
+    variant_alt : sequence or str
+        Alternate sequence to insert
+    """
+    n_variant_ref = len(variant_ref)
+    sequence_ref = sequence[position:position + n_variant_ref]
+    assert str(sequence_ref) == str(variant_ref), \
+        "Reference %s at position %d != expected reference %s" % \
+        (sequence_ref, position, variant_ref)
+    prefix = sequence[:position]
+    suffix = sequence[position + n_variant_ref:]
+    return prefix + variant_alt + suffix

--- a/varcode/mutate.py
+++ b/varcode/mutate.py
@@ -15,9 +15,52 @@
 from __future__ import print_function, division, absolute_import
 
 
-def mutate(sequence, position, variant_ref, variant_alt):
+def insert_before(sequence, offset, new_residues):
+    """Mutate the given sequence by inserting the string `new_residues` before
+    `offset`.
+
+    Parameters
+    ----------
+    sequence : sequence
+        String of amino acids or DNA bases
+
+    offset : int
+        Base 0 offset from start of sequence, after which we should insert
+        `new_residues`.
+
+    new_residues : sequence
     """
-    Mutate a sequence by substituting given `alt` at instead of `ref` at the
+    assert 0 < offset <= len(sequence), \
+        "Invalid position %d for sequence of length %d" % (
+            offset, len(sequence))
+    prefix = sequence[:offset]
+    suffix = sequence[offset:]
+    return prefix + new_residues + suffix
+
+def insert_after(sequence, offset, new_residues):
+    """Mutate the given sequence by inserting the string `new_residues` after
+    `offset`.
+
+    Parameters
+    ----------
+    sequence : sequence
+        String of amino acids or DNA bases
+
+    offset : int
+        Base 0 offset from start of sequence, after which we should insert
+        `new_residues`.
+
+    new_residues : sequence
+    """
+    assert 0 <= offset < len(sequence), \
+        "Invalid position %d for sequence of length %d" % (
+            offset, len(sequence))
+    prefix = sequence[:offset + 1]
+    suffix = sequence[offset + 1:]
+    return prefix + new_residues + suffix
+
+def substitute(sequence, offset, ref, alt):
+    """Mutate a sequence by substituting given `alt` at instead of `ref` at the
     given `position`.
 
     Parameters
@@ -25,20 +68,20 @@ def mutate(sequence, position, variant_ref, variant_alt):
     sequence : sequence
         String of amino acids or DNA bases
 
-    position : int
-        Position in the sequence, starts from 0
+    offset : int
+        Base 0 offset from start of `sequence`
 
-    variant_ref : sequence or str
+    ref : sequence or str
         What do we expect to find at the position?
 
-    variant_alt : sequence or str
+    alt : sequence or str
         Alternate sequence to insert
     """
-    n_variant_ref = len(variant_ref)
-    sequence_ref = sequence[position:position + n_variant_ref]
-    assert str(sequence_ref) == str(variant_ref), \
-        "Reference %s at position %d != expected reference %s" % \
-        (sequence_ref, position, variant_ref)
-    prefix = sequence[:position]
-    suffix = sequence[position + n_variant_ref:]
-    return prefix + variant_alt + suffix
+    n_ref = len(ref)
+    sequence_ref = sequence[offset:offset + n_ref]
+    assert str(sequence_ref) == str(ref), \
+        "Reference %s at offset %d != expected reference %s" % \
+        (sequence_ref, offset, ref)
+    prefix = sequence[:offset]
+    suffix = sequence[offset + n_ref:]
+    return prefix + alt + suffix

--- a/varcode/transcript_helpers.py
+++ b/varcode/transcript_helpers.py
@@ -47,6 +47,5 @@ def interval_offset_on_transcript(start, end, transcript):
     # trim the end position to the end of the transcript
     if end > transcript.end:
         end = transcript.end
-
     # return earliest offset into the spliced transcript
     return min(transcript.spliced_offset(start), transcript.spliced_offset(end))

--- a/varcode/transcript_helpers.py
+++ b/varcode/transcript_helpers.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+
 def interval_offset_on_transcript(start, end, transcript):
     """
     Given an interval [start:end] and a particular transcript,
@@ -48,4 +49,6 @@ def interval_offset_on_transcript(start, end, transcript):
     if end > transcript.end:
         end = transcript.end
     # return earliest offset into the spliced transcript
-    return min(transcript.spliced_offset(start), transcript.spliced_offset(end))
+    return min(
+        transcript.spliced_offset(start),
+        transcript.spliced_offset(end))

--- a/varcode/util.py
+++ b/varcode/util.py
@@ -22,6 +22,7 @@ from pyensembl.release_info import MAX_ENSEMBL_RELEASE
 
 from .nucleotides import VALID_NUCLEOTIDES
 from .variant import Variant
+from .variant_collection import VariantCollection
 
 # cache lists of all transcript IDs for difference Ensembl releases
 _transcript_ids_cache = {}
@@ -67,4 +68,4 @@ def random_variants(count, ensembl_release=MAX_ENSEMBL_RELEASE):
             alt=alt,
             ensembl=ensembl)
         variants.append(variant)
-    return variants
+    return VariantCollection(variants)

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -35,6 +35,7 @@ from .effects import (
     IntronicSpliceSite,
     SpliceAcceptor,
     SpliceDonor,
+    StartLoss,
 )
 from .effect_ordering import top_priority_transcript_effect
 from .nucleotides import normalize_nucleotide_string
@@ -398,14 +399,15 @@ class Variant(object):
 
         utr5_length = min(transcript.start_codon_spliced_offsets)
 
+        # does the variant start inside the 5' UTR?
         if utr5_length > offset_with_utr5:
-            # TODO: what do we do if the variant spans the beginning of
-            # the coding sequence?
+
+            # does the variant end after the 5' UTR, within the coding region?
             if utr5_length < offset_with_utr5 + len(ref):
-                raise ValueError(
-                    "Variant which span 5' UTR and CDS not supported: %s" % (
-                        self,))
-            return FivePrimeUTR(self, transcript)
+                return StartLoss(self, transcript)
+            else:
+                # if variant contained within 5' UTR
+                return FivePrimeUTR(self, transcript)
 
         utr3_offset = max(transcript.stop_codon_spliced_offsets) + 1
 

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -95,7 +95,7 @@ class Variant(object):
             allow_extended_nucleotides=allow_extended_nucleotides)
         self.original_alt = normalize_nucleotide_string(alt,
             allow_extended_nucleotides=allow_extended_nucleotides)
-        self.original_pos = int(pos)
+        self.original_start = int(pos)
 
         # normalize the variant by trimming any shared prefix or suffix
         # between ref and alt nucleotide sequences and then
@@ -109,12 +109,12 @@ class Variant(object):
         # position for an insertion is
         #   "insert the alt nucleotides after this position"
         if len(trimmed_ref) == 0:
-            self.start = self.original_pos + max(0, len(prefix) - 1)
+            self.start = self.original_start + max(0, len(prefix) - 1)
             self.end = self.start
         else:
             # for substitutions and deletions the [start:end] interval is
             # an inclusive selection of reference nucleotides
-            self.start = self.original_pos + len(prefix)
+            self.start = self.original_start + len(prefix)
             self.end = self.start + len(trimmed_ref) - 1
 
         require_instance(ensembl, EnsemblRelease, "ensembl")
@@ -219,7 +219,7 @@ class Variant(object):
             self.contig, self.start, self.end)
 
     @memoize
-    def gene_names(self, only_coding=False):
+    def gene_names(self):
         """
         Return names of all genes which overlap this variant. Calling
         this method is significantly cheaper than calling `Variant.genes()`,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -25,6 +25,7 @@ from .coding_effect import infer_coding_effect
 from .common import groupby_field, memoize
 from .effects import (
     TranscriptMutationEffect,
+    Failure,
     Intergenic,
     Intragenic,
     NoncodingTranscript,
@@ -289,6 +290,7 @@ class Variant(object):
                         if raise_on_error:
                             raise
                         else:
+                            effects.append(Failure(self, transcript))
                             logging.warn(
                                 "Encountered error annotating %s for %s: %s",
                                 self,

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -183,12 +183,12 @@ class VariantCollection(object):
         }
 
     @memoize
-    def gene_counts(self, only_coding=False):
+    def gene_counts(self):
         """
         Count how many variants overlap each gene name.
         """
         counter = Counter()
         for variant in self.variants:
-            for gene_name in variant.gene_names(only_coding=only_coding):
+            for gene_name in variant.gene_names():
                 counter[gene_name] += 1
         return counter

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -100,7 +100,7 @@ class VariantCollection(object):
             original_filename=self.original_filename)
 
     @memoize
-    def high_impact_effects(self, *args, **kwargs):
+    def high_priority_effects(self, *args, **kwargs):
         """Like VariantCollection.effects() but only returns effects whose
         priority is at least as high as a missense mutation
         (e.g. frameshifts, splice site mutations, &c).

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -15,7 +15,9 @@
 # required so that 'import vcf' gets the global PyVCF package,
 # rather than our local vcf module
 from __future__ import absolute_import
+
 import typechecks
+from pyensembl import EnsemblRelease
 
 from .reference_name import (
     infer_reference_name,
@@ -23,7 +25,6 @@ from .reference_name import (
 )
 from .variant import Variant
 from .variant_collection import VariantCollection
-from pyensembl import EnsemblRelease
 
 import vcf  # PyVCF
 
@@ -74,7 +75,7 @@ def load_vcf(
                     continue
                 variant = Variant(
                     contig=record.CHROM,
-                    pos=record.POS,
+                    start=record.POS,
                     ref=record.REF,
                     alt=alt.sequence,
                     info=record.INFO,


### PR DESCRIPTION
* added unit test module for "problematic" variants (anything which raises an exception when annotating variants in the wild, e.g. from TCGA MAF files)
* `Variant` now trims any shared suffix or prefix strings from `ref` and `alt` and adjusts the variant position accordingly. The position field has been renamed to `start`. The original variant fields are preserved as `Variant.original_ref`, `Variant.original_alt`, `Variant.original_start`. For example, if a VCF contains "chr1 10 CAG CATG", then the corresponding `Variant` object will have `ref = ""`, `alt = "T"`, `start = 11`, `original_ref = "CAG"`, `original_alt = "CATG"`, `original_start = 10`. 
* Renamed `top_priority_transcript_effect` to `top_priority_effect` (since we now have effects like `Intergenic` which aren't tied to a particular transcript)
* Added `ExonLoss` as an effect
* Reorganized the effect annotation logic in `Variant` to deal with variants which span feature boundaries (e.g. deletions which affect both an exon and its neighboring intron). 
* renamed `VariantCollection.variant_effects` to just `VariantCollection.effects`
* renamed `VariantCollection.variant_summary` to `VariantCollection.summary_string`
* added unit tests for misc. `VariantCollection` methods

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/37)
<!-- Reviewable:end -->
