### PR TITLE
Use transcript protein sequence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
         install_requires=[
             'numpy>=1.7',
             'pandas>=0.13.1',
-            'pyensembl>=0.6.1,<0.7.0',
+            'pyensembl>=0.6.2,<0.7.0',
             'biopython',
             'pyvcf',
             'memoized_property'

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     setup(
         name='varcode',
         packages=['varcode'],
-        version="0.0.3",
+        version="0.1.0",
         description="Variant annotation in Python",
         long_description=readme,
         url="https://github.com/hammerlab/varcode",
@@ -59,7 +59,7 @@ if __name__ == '__main__':
         install_requires=[
             'numpy>=1.7',
             'pandas>=0.13.1',
-            'pyensembl>=0.5.11',
+            'pyensembl>=0.6.1,<0.7.0',
             'biopython',
             'pyvcf',
             'memoized_property'

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -8,6 +8,7 @@ from pyensembl import EnsemblRelease
 from varcode import Variant
 
 ensembl75 = EnsemblRelease(75)
+ensembl78 = EnsemblRelease(78)
 
 # variants which have previously resulted in raised exceptions
 # during effect annotation
@@ -77,6 +78,22 @@ should_not_crash_variants = [
         ref="CCGACATC",
         alt="",
         ensembl=ensembl75),
+    # error message:
+    # "Can't have empty aa_ref and aa_alt"
+    Variant(
+        contig=8,
+        start=141488566,
+        ref="T",
+        alt="C",
+        ensembl=ensembl78),
+    # error message:
+    # "len(aa_alt) = 0"
+    Variant(
+        contig=11,
+        start=57741870,
+        ref="G",
+        alt="C",
+        ensembl=ensembl78),
 ]
 
 def try_effect_annotation(variant):

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -15,6 +15,9 @@
 from __future__ import print_function, division, absolute_import
 import logging
 
+# from Bio.Seq import Seq
+from Bio.Data import CodonTable
+
 from .effects import (
     Silent,
     Insertion,
@@ -32,11 +35,27 @@ from .effects import (
 from .mutate import substitute, insert_after
 from .string_helpers import trim_shared_flanking_strings
 
-# from Bio.Seq import Seq
-from Bio.Data import CodonTable
-
+DNA_CODON_TABLE = CodonTable.standard_dna_table.forward_table
 START_CODONS = set(CodonTable.standard_dna_table.start_codons)
 STOP_CODONS = set(CodonTable.standard_dna_table.stop_codons)
+
+def translate_codon(codon, aa_pos):
+    """Translate a single codon into a single amino acid or stop '*'
+
+    Parameters
+    ----------
+    codon : str
+        Expected to be of length 3
+    aa_pos : int
+        Codon/amino acid offset into the protein (starting from 0)
+    """
+    # not handling rare Leucine or Valine starts!
+    if aa_pos == 0 and codon in START_CODONS:
+        return "M"
+    elif codon in STOP_CODONS:
+        return "*"
+    else:
+        return DNA_CODON_TABLE[codon]
 
 def translate(cds_seq):
     """Translates cDNA coding sequence into amino acid protein sequence.
@@ -73,8 +92,77 @@ def translate(cds_seq):
         return "M" + protein[1:]
     return protein
 
+def snv_coding_effect(
+        ref,
+        alt,
+        cds_seq,
+        cds_offset,
+        transcript,
+        variant):
+    """Coding effect of a single nucleotide substitution"""
+    aa_pos = int(cds_offset / 3)
+    assert aa_pos <= len(transcript.protein_sequence)
 
-def infer_coding_effect(
+    # codon in the reference sequence
+    ref_codon = str(cds_seq[aa_pos * 3:aa_pos * 3 + 3])
+    # which nucleotide of the codon got changed?
+    codon_offset = cds_offset % 3
+    mutant_codon = (
+        ref_codon[:codon_offset] + alt + ref_codon[codon_offset + 1:])
+    assert len(mutant_codon) == 3, \
+        "Expected codon to have length 3, got %s (length = %d)" % (
+            mutant_codon, len(mutant_codon))
+    if aa_pos == 0:
+        if mutant_codon in START_CODONS:
+            # if we changed the starting codon treat then
+            # this is technically a Silent mutation but may cause
+            # alternate starts or other effects
+            return AlternateStartCodon(
+                variant,
+                transcript,
+                ref_codon,
+                mutant_codon)
+        else:
+            # if we changed a start codon to something else then
+            # we no longer know where the protein begins (or even in
+            # what frame).
+            # TODO: use the Kozak consensus sequence or a predictive model
+            # to identify the most likely start site
+            return StartLoss(
+                variant=variant,
+                transcript=transcript,
+                aa_alt=translate_codon(mutant_codon, 0))
+
+    original_amino_acid = translate_codon(ref_codon, aa_pos)
+    mutant_amino_acid = translate_codon(mutant_codon, aa_pos)
+
+    if original_amino_acid == mutant_amino_acid:
+        return Silent(
+            variant,
+            transcript,
+            aa_pos=aa_pos,
+            aa_ref=original_amino_acid)
+    elif aa_pos == len(transcript.protein_sequence):
+        # if non-silent mutation is at the end of the protein then
+        # should be a stop-loss
+        assert original_amino_acid == "*"
+        # if mutatin is at the end of the protein and both
+        assert mutant_amino_acid != "*"
+        return StopLoss(
+            variant,
+            transcript,
+            aa_pos=aa_pos,
+            aa_alt=mutant_amino_acid)
+    else:
+        # simple substitution e.g. p.V600E
+        return Substitution(
+            variant,
+            transcript,
+            aa_pos=aa_pos,
+            aa_ref=original_amino_acid,
+            aa_alt=mutant_amino_acid)
+
+def coding_effect(
         ref,
         alt,
         transcript_offset,
@@ -145,6 +233,14 @@ def infer_coding_effect(
             transcript, cds_seq))
 
     original_protein = transcript.protein_sequence
+
+    if not original_protein:
+        # Ensembl should have given us a protein sequence for every
+        # transcript but it's possible that we're trying to annotate a
+        # transcript whose biotype isn't included in the protein sequence FASTA
+        logging.warn("No protein sequence for %s in Ensembl", transcript)
+        original_protein = translate(cds_seq)
+
     # subtract 3 for the stop codon and divide by 3 since
     # 3 nucleotides = 1 codon = 1 amino acid
     expected_protein_length = int((len(cds_seq) - 3) / 3)
@@ -156,6 +252,20 @@ def infer_coding_effect(
                 expected_protein_length,
                 len(original_protein),
                 original_protein))
+
+    # genomic position to codon position
+    aa_pos = int(cds_offset / 3)
+
+    # special case simplified logic for an SNV
+    # TODO: generalize for all in-frame substitutions
+    if len(ref) == len(alt) == 1:
+        return snv_coding_effect(
+            ref,
+            alt,
+            cds_seq,
+            cds_offset,
+            transcript,
+            variant)
 
     transcript_after_start_codon = sequence[cds_start_offset:]
 
@@ -195,9 +305,6 @@ def infer_coding_effect(
     if len(variant_protein) == 0:
         raise ValueError(
             "Translated mutant protein sequence of %s is empty" % (transcript,))
-
-    # genomic position to codon position
-    aa_pos = int(cds_offset / 3)
 
     if original_protein == variant_protein:
         original_start_codon = cds_seq[:3]
@@ -336,6 +443,7 @@ def infer_coding_effect(
     else:
         last_aa_alt_pos = int((cds_offset + len(alt) - 1) / 3)
         aa_alt = variant_protein[aa_pos:last_aa_alt_pos + 1]
+
     assert len(alt) == 0 or len(aa_alt) > 0, \
             "len(aa_alt) = 0 for variant %s on transcript %s (aa_pos=%d)" % (
                 variant, transcript, aa_pos)
@@ -349,10 +457,13 @@ def infer_coding_effect(
     # get rid of the shared prefixes/suffixes
     aa_ref, aa_alt, prefix, suffix = trim_shared_flanking_strings(
         aa_ref, aa_alt)
-
+    print("ref '%s'" % aa_ref, "alt '%s'" % aa_alt, "prefix '%s'" % prefix, "suffix '%s'" % suffix)
     aa_pos += len(prefix)
 
     if frameshift:
+        # is aa_ref still inside the original protein?
+        print(aa_pos, len(original_protein))
+        print(original_protein)
         aa_ref = original_protein[aa_pos]
         # if a frameshift doesn't create any new amino acids, then
         # it must immediately have hit a stop codon
@@ -399,16 +510,13 @@ def infer_coding_effect(
             variant, transcript,
             aa_pos=aa_pos,
             aa_alt=aa_alt)
-
-    # simple substitution e.g. p.V600E
-    elif len(aa_ref) == 1 and len(aa_alt) == 1:
+    elif len(aa_ref) == len(aa_alt) == 1:
         return Substitution(
             variant,
             transcript,
             aa_pos=aa_pos,
             aa_ref=aa_ref,
             aa_alt=aa_alt)
-
     # substitution which involes multiple amino acids
     # Example: p.V600EEQ, p.IL49AQY
     else:

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -457,13 +457,9 @@ def coding_effect(
     # get rid of the shared prefixes/suffixes
     aa_ref, aa_alt, prefix, suffix = trim_shared_flanking_strings(
         aa_ref, aa_alt)
-    print("ref '%s'" % aa_ref, "alt '%s'" % aa_alt, "prefix '%s'" % prefix, "suffix '%s'" % suffix)
     aa_pos += len(prefix)
 
     if frameshift:
-        # is aa_ref still inside the original protein?
-        print(aa_pos, len(original_protein))
-        print(original_protein)
         aa_ref = original_protein[aa_pos]
         # if a frameshift doesn't create any new amino acids, then
         # it must immediately have hit a stop codon

--- a/varcode/effect_ordering.py
+++ b/varcode/effect_ordering.py
@@ -51,7 +51,8 @@ transcript_effect_priority_list = [
     # modification or deletion of a start codon
     StartLoss,
     # out-of-frame insertion or deletion
-    FrameShift
+    FrameShift,
+    ExonLoss,
 ]
 
 transcript_effect_priority_dict = {

--- a/varcode/util.py
+++ b/varcode/util.py
@@ -28,7 +28,11 @@ from .variant_collection import VariantCollection
 _transcript_ids_cache = {}
 
 
-def random_variants(count, ensembl_release=MAX_ENSEMBL_RELEASE):
+def random_variants(
+        count,
+        ensembl_release=MAX_ENSEMBL_RELEASE,
+        deletions=True,
+        insertions=True):
     """
     Generate a VariantCollection with random variants that overlap
     at least one complete coding transcript.
@@ -60,6 +64,15 @@ def random_variants(count, ensembl_release=MAX_ENSEMBL_RELEASE):
         if transcript.on_backward_strand:
             ref = reverse_complement(ref)
         alt_nucleotides = [x for x in VALID_NUCLEOTIDES if x != ref]
+        if insertions:
+            nucleotide_pairs = [
+                x + y
+                for x in alt_nucleotides
+                for y in VALID_NUCLEOTIDES
+            ]
+            alt_nucleotides.extend(nucleotide_pairs)
+        if deletions:
+            alt_nucleotides.append("")
         alt = random.choice(alt_nucleotides)
         variant = Variant(
             transcript.contig,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -21,7 +21,7 @@ from pyensembl.locus import normalize_chromosome
 from pyensembl.biotypes import is_coding_biotype
 from typechecks import require_instance
 
-from .coding_effect import infer_coding_effect
+from .coding_effect import coding_effect
 from .common import groupby_field, memoize
 from .effects import (
     TranscriptMutationEffect,
@@ -464,7 +464,7 @@ class Variant(object):
         if offset_with_utr5 >= utr3_offset:
             return ThreePrimeUTR(self, transcript)
 
-        return infer_coding_effect(
+        return coding_effect(
             strand_ref,
             strand_alt,
             offset_with_utr5,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -127,7 +127,7 @@ class Variant(object):
 
     @property
     def reference_name(self):
-        return self.ensembl.reference.reference_name
+        return self.ensembl.reference_name
 
     def __str__(self):
         return "Variant(contig=%s, start=%d, ref=%s, alt=%s, genome=%s)" % (


### PR DESCRIPTION
Overall motivation: move toward translating as few codons as necessary for each annotation (instead of always translating the full original & mutated proteins)

* Use `transcript.protein_sequence` instead of translating original protein
* Created special case for SNVs in `coding_effect` (plan to generalize this as a cleaner logic for all in-frame coding effects), translates only single affected codon
* Uses PyEnsembl 0.6.2


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/45)
<!-- Reviewable:end -->
