### PR TITLE
don't annotate StopLoss variants that are immediately followed by another stop codon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     setup(
         name='varcode',
         packages=['varcode'],
-        version="0.1.0",
+        version="0.1.1",
         description="Variant annotation in Python",
         long_description=readme,
         url="https://github.com/hammerlab/varcode",

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -7,8 +7,8 @@ test module.
 from pyensembl import EnsemblRelease
 from varcode import Variant
 
-ensembl75 = EnsemblRelease(75)
-ensembl78 = EnsemblRelease(78)
+ensembl_grch37 = EnsemblRelease(75)
+ensembl_grch38 = EnsemblRelease(79)
 
 # variants which have previously resulted in raised exceptions
 # during effect annotation
@@ -20,7 +20,7 @@ should_not_crash_variants = [
         start=92979092,
         ref="ATATATATATATATATATATATATATATATATG",
         alt="A",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     # error message:
     # "Expect non-silent stop-loss variant to cause longer variant protein"
     # "" but got len(original) = 653, len(variant) = 653"
@@ -29,7 +29,7 @@ should_not_crash_variants = [
         start=167385324,
         ref="TAA",
         alt="T",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     # error message:
     # "Variant which span 5' UTR and CDS not supported"
     Variant(
@@ -37,7 +37,7 @@ should_not_crash_variants = [
         start=44351166,
         ref="GGGAGAT",
         alt="G",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     # error message:
     # "Can't have ref = '' and alt = 'E' at aa_pos = 445, cds_pos = 1335"
     Variant(
@@ -45,31 +45,31 @@ should_not_crash_variants = [
         start=1684347,
         ref="",
         alt="CCT",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     Variant(
         contig=11,
         start=47640416,
         ref="",
         alt="TCTTT",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     Variant(
         contig=12,
         start=98880902,
         ref="A",
         alt="",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     Variant(
         contig=19,
         start=52803670,
         ref="TG",
         alt="",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     Variant(
         contig=1,
         start=109792735,
         ref="",
         alt="CGC",
-        ensembl=ensembl75),
+        ensembl=ensembl_grch37),
     # error message:
     # "expected ref 'GATGTCGG' at offset 1412 of ENST00000297524...CDS has 'G'"
     Variant(
@@ -77,23 +77,27 @@ should_not_crash_variants = [
         start=87226635,
         ref="CCGACATC",
         alt="",
-        ensembl=ensembl75),
-    # error message:
-    # "Can't have empty aa_ref and aa_alt"
+        ensembl=ensembl_grch37),
+    # error message: "Can't have empty aa_ref and aa_alt"
     Variant(
         contig=8,
         start=141488566,
         ref="T",
         alt="C",
-        ensembl=ensembl78),
-    # error message:
-    # "len(aa_alt) = 0"
+        ensembl=ensembl_grch38),
+    # error message: "len(aa_alt) = 0"
     Variant(
         contig=11,
         start=57741870,
         ref="G",
         alt="C",
-        ensembl=ensembl78),
+        ensembl=ensembl_grch38),
+    # error message: "IndexError: string index out of range"
+    Variant(
+        contig=11,
+        start=63676705,
+        ref="T", alt="",
+        ensembl=ensembl_grch37)
 ]
 
 def try_effect_annotation(variant):

--- a/test/test_timings.py
+++ b/test/test_timings.py
@@ -26,8 +26,18 @@ def _time_variant_annotation(variant_collection):
     return elapsed_t
 
 
-def test_effect_timing(n_variants=100):
-    variant_collection = random_variants(n_variants, random_seed=0)
+def test_effect_timing(
+        n_variants=100,
+        random_seed=0,
+        n_warmup_variants=20):
+    warmup_collection = random_variants(
+        n_warmup_variants,
+        random_seed=None)
+    warmup_collection.effects()
+
+    variant_collection = random_variants(
+        n_variants,
+        random_seed=random_seed)
     elapsed_t = _time_variant_annotation(variant_collection)
     print("Elapsed: %0.4f for %d variants" % (elapsed_t, n_variants))
     assert elapsed_t / n_variants < 0.1, \

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -490,7 +490,7 @@ class PrematureStop(BaseSubstitution):
 
         assert self.stop_codon_offset < len(transcript.protein_sequence), \
             ("Premature stop codon cannot be at position %d"
-             "since the original protein of %s has length %d") % (
+             " since the original protein of %s has length %d") % (
                 self.stop_codon_offset,
                 transcript,
                 len(transcript.protein_sequence))

--- a/varcode/frameshift_coding_effect.py
+++ b/varcode/frameshift_coding_effect.py
@@ -25,6 +25,7 @@ from .effects import (
     Silent
 )
 from .mutate import substitute
+from .string_helpers import trim_shared_prefix
 from .translate import translate
 
 def _frameshift(
@@ -55,36 +56,34 @@ def _frameshift(
         "Expect transcript %s to have protein sequence" % transcript
 
     original_protein_sequence = transcript.protein_sequence
+    original_protein_length = len(original_protein_sequence)
 
-    protein_suffix = translate(
+    mutant_protein_suffix = translate(
         nucleotide_sequence=sequence_from_mutated_codon,
         first_codon_is_start=False,
         to_stop=True,
         truncate=True)
 
-    if mutated_codon_index == len(original_protein_sequence):
+    if mutated_codon_index == original_protein_length:
         return StopLoss(
             variant=variant,
             transcript=transcript,
-            extended_protein_sequence=protein_suffix)
+            extended_protein_sequence=mutant_protein_suffix)
 
     # the frameshifted sequence may contain some amino acids which are
     # the same as the original protein!
-    n_skip = 0
+    if mutated_codon_index == original_protein_length:
+        n_unchanged_amino_acids = 0
+    else:
+        _, mutant_protein_suffix, unchanged_amino_acids = trim_shared_prefix(
+            ref=original_protein_sequence[mutated_codon_index:],
+            alt=mutant_protein_suffix)
+        n_unchanged_amino_acids = len(unchanged_amino_acids)
 
-    for i, new_amino_acid in enumerate(protein_suffix):
-        codon_index = mutated_codon_index + i
-        if codon_index >= len(original_protein_sequence):
-            break
-        elif original_protein_sequence[codon_index] != new_amino_acid:
-            break
-        n_skip += 1
-
-    protein_suffix = protein_suffix[n_skip:]
-
-    if mutated_codon_index + n_skip == len(original_protein_sequence):
+    mutation_start_position = mutated_codon_index + n_unchanged_amino_acids
+    if mutation_start_position == original_protein_length:
         # frameshift is either extending the protein or leaving it unchanged
-        if len(protein_suffix) == 0:
+        if len(mutant_protein_suffix) == 0:
             # miraculously, this frameshift left the protein unchanged,
             # most likely by turning one stop codon into another stop codon
             return Silent(
@@ -93,32 +92,34 @@ def _frameshift(
                 aa_pos=mutated_codon_index,
                 aa_ref=original_protein_sequence[mutated_codon_index])
         else:
+            # When all the amino acids are the same as the original, we either
+            # have the original protein or we've extended it.
+            # If we've extended it, it means we must have lost our stop codon.
             return StopLoss(
                 variant=variant,
                 transcript=transcript,
-                extended_protein_sequence=protein_suffix)
+                extended_protein_sequence=mutant_protein_suffix)
 
-    aa_pos = mutated_codon_index + n_skip
     # original amino acid at the mutated codon before the frameshift occurred
-    aa_ref = original_protein_sequence[aa_pos]
+    aa_ref = original_protein_sequence[mutation_start_position]
 
     # TODO: what if all the shifted amino acids were the same and the protein
     # ended up the same length?
     # Add a Silent case
-    if len(protein_suffix) == 0:
+    if len(mutant_protein_suffix) == 0:
         # if a frameshift doesn't create any new amino acids, then
         # it must immediately have hit a stop codon
         return FrameShiftTruncation(
             variant=variant,
             transcript=transcript,
-            stop_codon_offset=aa_pos,
+            stop_codon_offset=mutation_start_position,
             aa_ref=aa_ref)
     return FrameShift(
         variant=variant,
         transcript=transcript,
-        aa_pos=aa_pos,
+        aa_pos=mutation_start_position,
         aa_ref=aa_ref,
-        shifted_sequence=protein_suffix)
+        shifted_sequence=mutant_protein_suffix)
 
 def frameshift_coding_insertion_effect(
         cds_offset_before_insertion,

--- a/varcode/in_frame_coding_effect.py
+++ b/varcode/in_frame_coding_effect.py
@@ -285,12 +285,20 @@ def in_frame_coding_effect(
             if mutant_protein_subsequence[i] != x:
                 break
             n_shared_amino_acids += 1
-        return PrematureStop(
-            variant=variant,
-            transcript=transcript,
-            aa_pos=first_ref_codon_index + n_shared_amino_acids,
-            aa_ref=original_protein_subsequence[n_shared_amino_acids:],
-            aa_alt=mutant_protein_subsequence[n_shared_amino_acids:])
+        mutation_aa_pos = first_ref_codon_index + n_shared_amino_acids
+        original_protein_subsequence = \
+            original_protein_subsequence[n_shared_amino_acids:]
+        mutant_protein_subsequence = \
+            mutant_protein_subsequence[n_shared_amino_acids:]
+        if mutation_aa_pos < len(original_protein_sequence) - 1:
+            # only call this mutation a premature stop if it decreases
+            # the length of the protein
+            return PrematureStop(
+                variant=variant,
+                transcript=transcript,
+                aa_pos=mutation_aa_pos,
+                aa_ref=original_protein_subsequence,
+                aa_alt=mutant_protein_subsequence)
 
     return _choose_annotation(
         aa_pos=first_ref_codon_index,

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -66,7 +66,9 @@ def load_maf_dataframe(filename, nrows=None, verbose=False):
         filename,
         comment="#",
         sep="\t",
-        low_memory=False)
+        low_memory=False,
+        skip_blank_lines=True,
+        header=0)
 
     if len(df.columns) < n_basic_columns:
         raise ValueError(

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -113,6 +113,7 @@ class Variant(object):
         # position for an insertion is
         #   "insert the alt nucleotides after this position"
         if len(trimmed_ref) == 0:
+            # start and end both are nucleotide before insertion
             self.start = self.original_start + max(0, len(prefix) - 1)
             self.end = self.start
         else:


### PR DESCRIPTION
Fixes https://github.com/hammerlab/varcode/issues/56

Also:
* Adds "warmup" to timing benchmarks 
* Make sure PrematureStop is actually generating a truncated protein (some variants that end in Stop codons inserted at the end may actually extend the protein)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/57)
<!-- Reviewable:end -->
