### PR TITLE
Use find_packages correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ except Exception as e:
 if __name__ == '__main__':
     setup(
         name='varcode',
-        packages=find_packages("test"),
-        version="0.3.10",
+        packages=find_packages(),
+        version="0.3.11",
         description="Variant annotation in Python",
         long_description=readme,
         url="https://github.com/hammerlab/varcode",


### PR DESCRIPTION
Fixes #84 

`find_packages` appears to either take an exclusion list or no args, rather than just `"test"`. With no args, it does include both `varcode` and `test`, as evidenced by the `top_level.txt`:

```
test
varcode
```

Before this fix, `top_level.txt` is empty and `import varcode` doesn't work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/85)
<!-- Reviewable:end -->
