### PR TITLE
Support for regular varcode variant instances in read evidence module

### DIFF
--- a/test/test_read_evidence.py
+++ b/test/test_read_evidence.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import collections
 from nose.tools import eq_, assert_raises
 import pysam
+from varcode import Variant as VarcodeVariant
 from varcode.read_evidence import PileupCollection
 from varcode import Locus
 from .data import data_path
@@ -202,6 +203,20 @@ def test_read_evidence_variant_matching_gatk_mini_bundle_extract():
             lambda e: e.read_attributes().mapping_quality.mean()),
         [('AC', 60.0), ('', 65.0)])
 
+def test_read_evidence_variant_matching_gatk_bundle_native_varcode_variant():
+    # Try native varcode Variant.
+    handle = pysam.Samfile(data_path("reads/gatk_mini_bundle_extract.bam"))
+    locus = Locus.from_inclusive_coordinates("20", 10008951)
+    variant = VarcodeVariant(
+        locus.contig,
+        locus.position + 1,  # inclusive not interbase
+        "A",
+        "C")
+    evidence = PileupCollection.from_bam(handle, [variant])
+    eq_(evidence.match_summary(variant),
+        [('A', 1), ('C', 4)])
+
+
 def test_read_evidence_variant_matching_gatk_mini_bundle_extract_warning():
     filename = data_path("reads/gatk_mini_bundle_extract.bam")
 
@@ -212,4 +227,5 @@ def test_read_evidence_variant_matching_gatk_mini_bundle_extract_warning():
     evidence = PileupCollection.from_bam(filename, loci)
     eq_(evidence.match_summary(Variant(loci[0], "A", "")),
         [('A', 0), ('', 0), ('AT', 3)])
+
 

--- a/varcode/read_evidence/pileup_collection.py
+++ b/varcode/read_evidence/pileup_collection.py
@@ -595,9 +595,20 @@ def to_locus(variant_or_locus):
     """
     Return a Locus object for a Variant instance.
 
-    Since the read evidence module uses a different Variant class than the rest
-    of varcode, this is necessary. This should be removed once varcode switches
-    to interbase coordinates.
+    This is necessary since the read evidence module expects Variant instances
+    to have a locus attribute st to a varcode.Locus instance of interbase
+    genomic coordinates.  The rest of varcode uses a different Variant class,
+    but will eventually be transitioned to interbase coordinates.
+
+    See test/test_read_evidence.py for a definition of the Variant class that
+    the read_evidence module is meant to work with.
+
+    This function can be passed a regular varcode.Variant instance (with fields
+    start, end, contig, etc.), a different kind of variant object that has a
+    'locus' field, or a varcode.Locus. It will return a varcode.Locus instance.
+
+    This should all get cleaned up once varcode switches to interbase
+    coordinates and we standardize on a Variant class.
     """
     if isinstance(variant_or_locus, Locus):
         return variant_or_locus


### PR DESCRIPTION
The read evidence module has been in an awkward place since it uses a different `Variant` class than the rest of varcode, as it uses interbase coordinates whereas the rest of varcode uses 1-based coordinates. (Varcode will eventually migrate entirely to interbase; see #40). This change makes this situation mildly less annoying by having the read evidence module take care of converting regular varcode `Variant` instances to the needed interase format.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/87)
<!-- Reviewable:end -->
