### PR TITLE
Warn when variants in MAF file have wrong end position

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     setup(
         name='varcode',
         packages=find_packages(),
-        version="0.3.15",
+        version="0.3.16",
         description="Variant annotation in Python",
         long_description=readme,
         url="https://github.com/hammerlab/varcode",

--- a/test/test_problematic_variants.py
+++ b/test/test_problematic_variants.py
@@ -147,6 +147,14 @@ should_not_crash_variants = [
         start=117120188,
         ref="A",
         alt="AAGT",
+        ensembl=ensembl_grch37),
+    # had problems with end coordinate loading this one from a MAF but also
+    # want to make sure it doesn't cause other trouble
+    Variant(
+        contig=1,
+        start=109461324,
+        ref="GG",
+        alt="TT",
         ensembl=ensembl_grch37)
 ]
 

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -151,7 +151,7 @@ def load_maf(path):
             end_offset = len(ref) - 1
         expected_end_pos = start_pos + end_offset
 
-        if len(ref) > 0 and abs(end_pos - expected_end_pos) > 1:
+        if len(ref) > 0 and end_pos != expected_end_pos:
             # only check for correct ending since the meaning of start/end
             # for insertions is different than for substitutions
             #

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-
+import logging
 
 import pandas
 from pyensembl import EnsemblRelease
@@ -150,10 +150,14 @@ def load_maf(path):
         else:
             end_offset = len(ref) - 1
         expected_end_pos = start_pos + end_offset
-        if len(ref) > 0 and end_pos != expected_end_pos:
+
+        if len(ref) > 0 and abs(end_pos - expected_end_pos) > 1:
             # only check for correct ending since the meaning of start/end
-            # for insertions is different thn for substitutions
-            raise ValueError(
+            # for insertions is different than for substitutions
+            #
+            # Only warn since some MAF files in the wild seem to violate
+            # expectations for end position coordinates
+            logging.warn(
                 "Expected variant %s:%s '%s' > '%s' to end at %d but got %d" % (
                     contig,
                     start_pos,


### PR DESCRIPTION
Some MAFs in the wild seem to have end positions which violate what's expected with base-1 inclusive coordinates, so warn about unexpected end positions instead of raising an exception. (fixes https://github.com/hammerlab/varcode/issues/105)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/115)
<!-- Reviewable:end -->
