### PR TITLE
Fix #116 and call PrematureStop when stop codon is added in the middle of an insertion

### DIFF
--- a/test/test_effect_classes.py
+++ b/test/test_effect_classes.py
@@ -352,3 +352,39 @@ def test_intronic():
         variant,
         transcript_id="ENST00000357654",
         effect_class=Intronic)
+
+def test_disruptive_insertion_stop_gain():
+    variant = Variant(
+        "7",
+        117182143,
+        ref="",
+        alt="GTA",
+        ensembl=ensembl_grch37)
+    expect_effect(
+        variant,
+        transcript_id="ENST00000003084",
+        effect_class=PrematureStop)
+
+def test_substitution_nonfinal_stop_gain():
+    variant = Variant(
+        "7",
+        117182145,
+        ref="ACAG",
+        alt="TAAC",
+        ensembl=ensembl_grch37)
+    expect_effect(
+        variant,
+        transcript_id="ENST00000003084",
+        effect_class=PrematureStop)
+
+def test_insertion_nonfinal_stop_gain():
+    variant = Variant(
+        "7",
+        117182144,
+        ref="",
+        alt="TAGGTT",
+        ensembl=ensembl_grch37)
+    expect_effect(
+        variant,
+        transcript_id="ENST00000003084",
+        effect_class=PrematureStop)

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -508,7 +508,7 @@ class Deletion(BaseSubstitution):
 
 
 class PrematureStop(BaseSubstitution):
-    """In-frame insertion of codons ending with a stop codon. May also involve
+    """In-frame insertion of codons containing a stop codon. May also involve
     insertion/deletion/substitution of other amino acids preceding the stop."""
     def __init__(
             self,

--- a/varcode/in_frame_coding_effect.py
+++ b/varcode/in_frame_coding_effect.py
@@ -177,9 +177,10 @@ def in_frame_coding_effect(
                 aa_alt=inserted_amino_acids)
         else:
             # inserting inside a reference codon
+            # include an extra codon at the end of the reference so that if we insert a stop before a stop, we can return Silent
             ref_codon = sequence_from_start_codon[
-                first_ref_codon_index * 3:first_ref_codon_index * 3 + 3]
-            last_ref_codon_index = first_ref_codon_index
+                first_ref_codon_index * 3:first_ref_codon_index * 3 + 6]
+            last_ref_codon_index = first_ref_codon_index + 1
             # split the reference codon into nucleotides before/after insertion
             prefix = ref_codon[:offset_in_first_ref_codon + 1]
             suffix = ref_codon[offset_in_first_ref_codon + 1:]

--- a/varcode/in_frame_coding_effect.py
+++ b/varcode/in_frame_coding_effect.py
@@ -17,6 +17,7 @@ Effect annotation for variants which modify the coding sequence without
 changing the reading frame.
 """
 
+import six
 from .effects import (
     Silent,
     Insertion,
@@ -162,7 +163,7 @@ def in_frame_coding_effect(
             # then we can just translate the inserted sequence since it's on
             # codon boundary
             inserted_amino_acids = translate(alt, first_codon_is_start=False)
-            if STOP_CODONS.intersection(alt[3*i:3*i + 3] for i in xrange(len(alt)/3)):
+            if STOP_CODONS.intersection(alt[3*i:3*i + 3] for i in six.moves.range(len(alt)/3)):
                 # if we're inserting an in-frame stop codon
                 return PrematureStop(
                     variant=variant,
@@ -263,7 +264,7 @@ def in_frame_coding_effect(
     mutant_protein_subsequence = translate(
         mutant_codons,
         first_codon_is_start=(first_ref_codon_index == 0))
-    if STOP_CODONS.intersection(mutant_codons[3*i:3*i + 3] for i in xrange(len(mutant_codons)/3)):
+    if STOP_CODONS.intersection(mutant_codons[3*i:3*i + 3] for i in six.moves.range(len(mutant_codons)/3)):
         # if the new coding sequence contains a stop codon, then this is a
         # PrematureStop mutation
 

--- a/varcode/in_frame_coding_effect.py
+++ b/varcode/in_frame_coding_effect.py
@@ -162,7 +162,7 @@ def in_frame_coding_effect(
             # then we can just translate the inserted sequence since it's on
             # codon boundary
             inserted_amino_acids = translate(alt, first_codon_is_start=False)
-            if alt[-3:] in STOP_CODONS:
+            if STOP_CODONS.intersection(alt[3*i:3*i + 3] for i in xrange(len(alt)/3)):
                 # if we're inserting an in-frame stop codon
                 return PrematureStop(
                     variant=variant,
@@ -263,7 +263,7 @@ def in_frame_coding_effect(
     mutant_protein_subsequence = translate(
         mutant_codons,
         first_codon_is_start=(first_ref_codon_index == 0))
-    if mutant_codons[-3:] in STOP_CODONS:
+    if STOP_CODONS.intersection(mutant_codons[3*i:3*i + 3] for i in xrange(len(mutant_codons)/3)):
         # if the new coding sequence contains a stop codon, then this is a
         # PrematureStop mutation
 


### PR DESCRIPTION
Fixes #116. Also ran into an issue that if a stop codon is not at the end of an in-frame coding variant, it will not get called a PrematureStop. I seems like it still should though, so I changed that too.

Here are three examples that were not called as PrematureStop before but are now.

Called Silent but should be PrematureStop
`7	117182143	.	T	TGTA	.	.	.	GT	0/1`
Called Deletion but should be PrematureStop
`7	117182143	.	TAACAG	TATAAC	.	.	.	GT	0/1`
Called Insertion but should be PrematureStop
`7	117182143	.	TA	TATAGGTT	.	.	.	GT	0/1`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/117)
<!-- Reviewable:end -->
