### PR TITLE
Update Varcode to work with new multi-species PyEnsembl 

### DIFF
--- a/test/test_cosmic_mutations.py
+++ b/test/test_cosmic_mutations.py
@@ -43,9 +43,12 @@ def _substitution(chrom, pos, dna_ref, dna_alt, transcript_id, aa_ref, aa_alt):
     effect = _get_effect(chrom, pos, dna_ref, dna_alt, transcript_id)
     assert isinstance(effect, Substitution), \
         "Expected effect to be substitution, got %s" % (effect,)
+
     assert effect.aa_ref == aa_ref, \
-        "Expected aa_ref='%s' but got %s" % (
-            aa_ref, effect)
+        "Expected aa_ref='%s' : %s but got %s : %s from %s" % (
+            aa_ref, type(aa_ref),
+            effect.aa_ref, type(effect.aa_ref),
+            effect)
     assert effect.aa_alt == aa_alt, \
         "Expected aa_alt='%s' but got %s" % (
             aa_alt, effect)

--- a/test/test_mouse.py
+++ b/test/test_mouse.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from nose.tools import eq_
 
 from varcode import load_vcf, load_vcf_fast, Variant, Substitution
-from pyensembl import Genome
+from pyensembl import Genome, EnsemblRelease
 from . import data_path
 
 MOUSE_GTF_PATH = "ftp://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz"
@@ -12,29 +12,73 @@ MOUSE_PROTEIN_FASTA_PATH = "ftp://ftp.ensembl.org/pub/release-81/fasta/mus_muscu
 
 MOUSE_VCF = data_path("mouse_vcf_dbsnp_chr1_partial.vcf")
 
-def test_load_vcf_mouse():
-    genome = Genome("GRCm38",
-                    gtf_path_or_url=MOUSE_GTF_PATH,
-                    transcript_fasta_path_or_url=MOUSE_TRANSCRIPT_FASTA_PATH,
-                    protein_fasta_path_or_url=MOUSE_PROTEIN_FASTA_PATH)
-    genome.install()
-    variants = load_vcf(MOUSE_VCF, genome=genome)
+explicit_url_genome = Genome(
+    reference_name="GRCm38",
+    annotation_name="ensembl",
+    annotation_version=81,
+    gtf_path_or_url=MOUSE_GTF_PATH,
+    transcript_fasta_path_or_url=MOUSE_TRANSCRIPT_FASTA_PATH,
+    protein_fasta_path_or_url=MOUSE_PROTEIN_FASTA_PATH)
+
+ensembl_mouse_genome = EnsemblRelease(81, species="mouse")
+
+def test_load_vcf_mouse_with_explicit_urls():
+    variants = load_vcf(MOUSE_VCF, genome=explicit_url_genome)
     eq_(len(variants), 217)
-    variants = load_vcf_fast(MOUSE_VCF, genome=genome)
+    variants = load_vcf_fast(MOUSE_VCF, genome=explicit_url_genome)
     eq_(len(variants), 217)
 
-def test_specific_variant_mouse():
-    genome = Genome("GRCm38",
-                    gtf_path_or_url=MOUSE_GTF_PATH,
-                    transcript_fasta_path_or_url=MOUSE_TRANSCRIPT_FASTA_PATH,
-                    protein_fasta_path_or_url=MOUSE_PROTEIN_FASTA_PATH)
-    genome.install()
+def test_load_vcf_mouse_with_ensembl_release():
+    variants = load_vcf(MOUSE_VCF, genome=ensembl_mouse_genome)
+    eq_(len(variants), 217)
+    variants = load_vcf_fast(MOUSE_VCF, genome=ensembl_mouse_genome)
+    eq_(len(variants), 217)
+
+def test_specific_variant_mouse_with_explicit_urls():
     # Exon #2 at http://useast.ensembl.org/Mus_musculus/Transcript/Exons?
     # db=core;g=ENSMUSG00000017167;r=11:101170523-101190724;t=ENSMUST00000103109
-    variant = Variant(contig=11, start=101177240, ref="G", alt="T", ensembl=genome)
+    variant = Variant(
+        contig=11,
+        start=101177240,
+        ref="G",
+        alt="T",
+        ensembl=explicit_url_genome)
     effects = variant.effects()
     eq_(len(effects), 2)
-    substitution_effects = [effect for effect in effects if isinstance(effect, Substitution)]
+    substitution_effects = [
+        effect
+        for effect in effects
+        if isinstance(effect, Substitution)
+    ]
+    eq_(len(substitution_effects), 1)
+    substitution_effect = substitution_effects[0]
+    # The coding sequence through the sub:
+    # ATGATGAGTCTCCGGCTCTTCAGCATCCTGCTCGCCACG
+    # GTGGTCTCTGGAGCTTGGGGCTGGGGCTACTACGGTTGC
+    # (The final G is the sub: the 77th nucleotide)
+    # TGC (C) -> TTC (F)
+    # 78 / 3 = 26
+    # 0-base = 25
+    eq_(substitution_effect.mutant_protein_sequence[25], "F")
+    eq_(substitution_effect.original_protein_sequence[25], "C")
+
+
+def test_specific_variant_mouse_with_ensembl_genome():
+    # Exon #2 at http://useast.ensembl.org/Mus_musculus/Transcript/Exons?
+    # db=core;g=ENSMUSG00000017167;r=11:101170523-101190724;t=ENSMUST00000103109
+    variant = Variant(
+        contig=11,
+        start=101177240,
+        ref="G",
+        alt="T",
+        ensembl=ensembl_mouse_genome)
+    effects = variant.effects()
+    eq_(len(effects), 2)
+    substitution_effects = [
+        effect
+        for effect in effects
+        if isinstance(effect, Substitution)
+    ]
     eq_(len(substitution_effects), 1)
     substitution_effect = substitution_effects[0]
     # The coding sequence through the sub:

--- a/test/test_mouse.py
+++ b/test/test_mouse.py
@@ -34,6 +34,12 @@ def test_load_vcf_mouse_with_ensembl_release():
     variants = load_vcf_fast(MOUSE_VCF, genome=ensembl_mouse_genome)
     eq_(len(variants), 217)
 
+def test_load_vcf_mouse_with_inferred_genome():
+    variants = load_vcf(MOUSE_VCF)
+    eq_(len(variants), 217)
+    variants = load_vcf_fast(MOUSE_VCF)
+    eq_(len(variants), 217)
+
 def test_specific_variant_mouse_with_explicit_urls():
     # Exon #2 at http://useast.ensembl.org/Mus_musculus/Transcript/Exons?
     # db=core;g=ENSMUSG00000017167;r=11:101170523-101190724;t=ENSMUST00000103109

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -14,6 +14,7 @@
 
 import os
 from nose.tools import eq_
+from pyensembl import cached_release
 from varcode import load_vcf, load_vcf_fast, Variant
 from . import data_path
 
@@ -35,15 +36,15 @@ def test_load_vcf_local():
     variants = load_vcf(VCF_FILENAME)
     assert variants.reference_names() == {"GRCh37"}
     assert len(variants) == 14
-    
+
     variants = load_vcf(VCF_FILENAME + ".gz")
     assert variants.reference_names() == {"GRCh37"}
     assert len(variants) == 14
-    
+
     variants = load_vcf("file://%s" % VCF_FILENAME)
     assert variants.reference_names() == {"GRCh37"}
     assert len(variants) == 14
-    
+
     variants = load_vcf("file://%s.gz" % VCF_FILENAME)
     assert variants.reference_names() == {"GRCh37"}
     assert len(variants) == 14
@@ -59,7 +60,7 @@ if RUN_TESTS_REQUIRING_INTERNET:
         variants = load_vcf(VCF_EXTERNAL_URL)
         assert variants.reference_names() == {"GRCh37"}
         assert len(variants) == 14
-        
+
         variants = load_vcf(VCF_EXTERNAL_URL + ".gz")
         assert variants.reference_names() == {"GRCh37"}
         assert len(variants) == 14
@@ -78,7 +79,7 @@ def test_pandas_and_pyvcf_implementations_equivalent():
         {'path': data_path("mutect-example.vcf")},
         {'path': data_path("strelka-example.vcf")},
         {'path': data_path("mutect-example-headerless.vcf"),
-          'ensembl_version': 75},
+          'genome': cached_release(75)},
     ]
     if RUN_TESTS_REQUIRING_INTERNET:
         paths.append({'path': VCF_EXTERNAL_URL})
@@ -93,13 +94,13 @@ def test_pandas_and_pyvcf_implementations_equivalent():
         eq_(vcf_pandas.metadata, vcf_pyvcf.metadata)
         assert len(vcf_pandas) > 1
         assert len(vcf_pyvcf) > 1
-    
+
     for kwargs in paths:
         yield (do_test, kwargs)
-        
+
 def test_reference_arg_to_load_vcf():
     variants = load_vcf(VCF_FILENAME)
-    eq_(variants, load_vcf(VCF_FILENAME, ensembl_version=75))
+    eq_(variants, load_vcf(VCF_FILENAME, genome=cached_release(75)))
     eq_(variants, load_vcf(VCF_FILENAME, reference_name="grch37"))
     eq_(variants, load_vcf(VCF_FILENAME, reference_name="GRCh37"))
     eq_(variants, load_vcf(VCF_FILENAME, reference_name="b37"))

--- a/varcode/coding_effect.py
+++ b/varcode/coding_effect.py
@@ -53,8 +53,8 @@ def coding_effect(
 
     # reference nucleotides found on the transcript, if these don't match
     # what we were told to expect from the variant then raise an exception
-    ref_nucleotides_from_transcript = \
-        sequence[transcript_offset:transcript_offset + len(ref)]
+    ref_nucleotides_from_transcript = str(
+        sequence[transcript_offset:transcript_offset + len(ref)])
 
     # Make sure that the reference sequence agrees with what we expected
     # from the VCF
@@ -106,7 +106,7 @@ def coding_effect(
         "Expected CDS offset (%d) < |CDS| (%d) for %s on %s" % (
             cds_offset, cds_len, variant, transcript)
 
-    sequence_from_start_codon = sequence[cds_start_offset:]
+    sequence_from_start_codon = str(sequence[cds_start_offset:])
 
     # is this an in-frame mutations?
     if (len(ref) - len(alt)) % 3 == 0:

--- a/varcode/effects.py
+++ b/varcode/effects.py
@@ -106,7 +106,6 @@ class MutationEffect(object):
 
 class Intergenic(MutationEffect):
     """Variant has unknown effect if it occurs between genes"""
-    
     short_description = "intergenic"
 
 

--- a/varcode/in_frame_coding_effect.py
+++ b/varcode/in_frame_coding_effect.py
@@ -16,8 +16,10 @@
 Effect annotation for variants which modify the coding sequence without
 changing the reading frame.
 """
+from __future__ import division, absolute_import, print_function
 
-import six
+from six.moves import range
+
 from .effects import (
     Silent,
     Insertion,
@@ -149,7 +151,7 @@ def in_frame_coding_effect(
     variant : Variant
     """
 
-    first_ref_codon_index = int(cds_offset / 3)
+    first_ref_codon_index = cds_offset // 3
 
     # which nucleotide of the first codon got changed?
     offset_in_first_ref_codon = cds_offset % 3
@@ -163,7 +165,9 @@ def in_frame_coding_effect(
             # then we can just translate the inserted sequence since it's on
             # codon boundary
             inserted_amino_acids = translate(alt, first_codon_is_start=False)
-            if STOP_CODONS.intersection(alt[3*i:3*i + 3] for i in six.moves.range(len(alt)/3)):
+            n_alt_codons = len(alt) // 3
+            if STOP_CODONS.intersection(
+                    alt[3 * i:3 * i + 3] for i in range(n_alt_codons)):
                 # if we're inserting an in-frame stop codon
                 return PrematureStop(
                     variant=variant,
@@ -264,7 +268,11 @@ def in_frame_coding_effect(
     mutant_protein_subsequence = translate(
         mutant_codons,
         first_codon_is_start=(first_ref_codon_index == 0))
-    if STOP_CODONS.intersection(mutant_codons[3*i:3*i + 3] for i in six.moves.range(len(mutant_codons)/3)):
+
+    n_mutant_codons = len(mutant_codons) // 3
+    if STOP_CODONS.intersection(
+            mutant_codons[3 * i:3 * i + 3]
+            for i in range(n_mutant_codons)):
         # if the new coding sequence contains a stop codon, then this is a
         # PrematureStop mutation
 

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -16,14 +16,11 @@ from __future__ import print_function, division, absolute_import
 import logging
 
 import pandas
-from pyensembl import EnsemblRelease
+from pyensembl import genome_for_reference_name
 from typechecks import require_string
 
 from .nucleotides import normalize_nucleotide_string
-from .reference_name import (
-    infer_reference_name,
-    ensembl_release_number_for_reference_name
-)
+from .reference_name import infer_reference_name
 from .variant import Variant
 from .variant_collection import VariantCollection
 
@@ -120,9 +117,7 @@ def load_maf(path):
                 reference_name = str(ncbi_build)
 
             reference_name = infer_reference_name(reference_name)
-            ensembl_release = ensembl_release_number_for_reference_name(
-                reference_name)
-            ensembl = EnsemblRelease(release=ensembl_release)
+            ensembl = genome_for_reference_name(reference_name)
             ensembl_objects[ncbi_build] = ensembl
 
         # have to try both Tumor_Seq_Allele1 and Tumor_Seq_Allele2

--- a/varcode/nucleotides.py
+++ b/varcode/nucleotides.py
@@ -69,12 +69,12 @@ def normalize_nucleotide_string(nucleotides, allow_extended_nucleotides=False):
     # some MAF files represent deletions/insertions with NaN ref/alt values
     if isinstance(nucleotides, float) and np.isnan(nucleotides):
         return ""
-    
+
     # VCF files sometimes have '.' ref or alt for insertions and deletions, and
     # MAF files sometimes have '-' ref or alt for insertions and deletions.
     if nucleotides == "." or nucleotides == "-":
         return ""
-    
+
     typechecks.require_string(nucleotides, "nucleotide string")
 
     nucleotides = nucleotides.upper()

--- a/varcode/reference_name.py
+++ b/varcode/reference_name.py
@@ -17,11 +17,20 @@ from __future__ import print_function, division, absolute_import
 # NCBI builds and hg releases aren't identical
 # but the differences are all on chrM and unplaced contigs
 reference_alias_dict = {
+    # human assemblies
     "NCBI36": ["hg18", "B36", "NCBI36"],
     "GRCh37": ["hg19", "B37", "NCBI37"],
     "GRCh38": ["hg38", "B38", "NCBI38"],
+    # mouse assemblies
     "GRCm37": ["mm9"],
-    "GRCm38": ["mm10"],
+    "GRCm38": [
+        "mm10",
+        "GCF_000001635.24",  # GRCm38.p4
+        "GCF_000001635.23",  # GRCm38.p3
+        "GCF_000001635.22",  # GRCm38.p2
+        "GCF_000001635.21",  # GRCm38.p1
+        "GCF_000001635.20",  # GRCm38
+    ],
 }
 
 def infer_reference_name(reference_name_or_path):
@@ -30,9 +39,11 @@ def infer_reference_name(reference_name_or_path):
     that reference's FASTA file), return its canonical name
     as used by Ensembl.
     """
+    # consider reference names in reverse alphabetical order so that
+    # e.g. GRCh38 comes before GRCh37
     for assembly_name in sorted(reference_alias_dict.keys(), reverse=True):
-        candiate_list = [assembly_name] + reference_alias_dict[assembly_name]
-        for candidate in candiate_list:
+        candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
+        for candidate in candidate_list:
             if candidate.lower() in reference_name_or_path.lower():
                 return assembly_name
     raise ValueError(

--- a/varcode/reference_name.py
+++ b/varcode/reference_name.py
@@ -14,31 +14,26 @@
 
 from __future__ import print_function, division, absolute_import
 
-def infer_reference_name(path):
-    # NCBI builds and hg releases aren't identical
-    # but the differences are all on chrM and unplaced contigs
-    candidates = {
-        'NCBI36': ['hg18', 'B36', 'GRCh36', 'NCBI36'],
-        'GRCh37': ['hg19', 'B37', 'GRCh37', 'NCBI37'],
-        'GRCh38': ['hg38', 'B38', 'GRCh38', 'NCBI38'],
-    }
+# NCBI builds and hg releases aren't identical
+# but the differences are all on chrM and unplaced contigs
+reference_alias_dict = {
+    "NCBI36": ["hg18", "B36", "NCBI36"],
+    "GRCh37": ["hg19", "B37", "NCBI37"],
+    "GRCh38": ["hg38", "B38", "NCBI38"],
+    "GRCm37": ["mm9"],
+    "GRCm38": ["mm10"],
+}
 
-    for name in sorted(candidates.keys(), reverse=True):
-        aliases = candidates[name]
-        for alias in aliases:
-            if alias in path:
-                return name
-            if alias.lower() in path:
-                return name
-
+def infer_reference_name(reference_name_or_path):
+    """
+    Given a string containing a reference name (such as a path to
+    that reference's FASTA file), return its canonical name
+    as used by Ensembl.
+    """
+    for assembly_name in sorted(reference_alias_dict.keys(), reverse=True):
+        candiate_list = [assembly_name] + reference_alias_dict[assembly_name]
+        for candidate in candiate_list:
+            if candidate.lower() in reference_name_or_path.lower():
+                return assembly_name
     raise ValueError(
-        "Failed to infer human genome assembly name for %s" % path)
-
-def ensembl_release_number_for_reference_name(name):
-    if name == "NCBI36":
-        return 54
-    elif name == "GRCh37":
-        return 75
-    else:
-        assert name == "GRCh38", "Unrecognized reference name: %s" % name
-        return 78
+        "Failed to infer genome assembly name for %s" % reference_name_or_path)

--- a/varcode/util.py
+++ b/varcode/util.py
@@ -18,7 +18,7 @@ import logging
 
 from Bio.Seq import reverse_complement
 from pyensembl import EnsemblRelease
-from pyensembl.release_info import MAX_ENSEMBL_RELEASE
+from pyensembl import MAX_ENSEMBL_RELEASE
 
 from .nucleotides import STANDARD_NUCLEOTIDES
 from .variant import Variant

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -610,8 +610,8 @@ class Variant(object):
             strand_ref = genome_ref
             strand_alt = genome_alt
 
-        expected_ref = transcript.sequence[
-            transcript_offset:transcript_offset + len(strand_ref)]
+        expected_ref = str(transcript.sequence[
+            transcript_offset:transcript_offset + len(strand_ref)])
 
         if strand_ref != expected_ref:
             raise ValueError(


### PR DESCRIPTION
The main change here is that we can no longer assume that a PyEnsembl release version refers uniquely to a genome, now we also need to figure out the species. Anywhere where the release version was used had to be updated to construct a species-specific EnsemblRelease object. 

Another change is that we can now rely on PyEnsembl to tell us which genome is the most recent for a particular reference name (instead of hard-coding release versions in ladder of if-statements). 

TODO in another PR: add unit tests with mm10 aligned VCFs

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/118)
<!-- Reviewable:end -->
