### PR TITLE
Include a link to the iPython notebook in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ when using the `varcode` for the first time.
 Example
 -------
 
+
 ```python
 import varcode
 
@@ -78,6 +79,8 @@ print(premature_stop_effect.transcript)
 print(premature_stop_effect.gene.name)
 ### 'TP53'
 ```
+
+If you are looking for a quick start guide, you can check out [this iPython book](./examples/varcode-quick_start.ipynb) that demonstrates simple use cases of Varcode
 
 Effect Types
 ------------


### PR DESCRIPTION
We have this iPython book under `examples/` folder (#110) , but looks like I forgot to add a link to it from the README file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/121)
<!-- Reviewable:end -->
