### PR TITLE
Quotes around nucleotides in Variant representation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     setup(
         name='varcode',
         packages=find_packages(),
-        version="0.4.3",
+        version="0.4.4",
         description="Variant annotation in Python",
         long_description=readme,
         url="https://github.com/hammerlab/varcode",

--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -74,8 +74,6 @@ def test_substitution_no_prefix():
     assert not variant.is_indel
     assert not variant.is_insertion
     assert not variant.is_deletion
-    assert variant.preserves_reading_frame
-
 
 def test_substitution_shared_prefix():
     variant = Variant(1, start=10, ref="AA", alt="AT")

--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -44,7 +44,6 @@ def test_insertion_shared_prefix():
     assert variant.is_indel
     assert variant.is_insertion
     assert not variant.is_deletion
-    assert not variant.preserves_reading_frame
 
 def test_insertion_no_prefix():
     variant = Variant(1, start=11, ref="", alt="T")
@@ -60,7 +59,6 @@ def test_insertion_no_prefix():
     assert variant.is_indel
     assert variant.is_insertion
     assert not variant.is_deletion
-    assert not variant.preserves_reading_frame
 
 def test_substitution_no_prefix():
     variant = Variant(1, start=11, ref="A", alt="T")
@@ -93,8 +91,6 @@ def test_substitution_shared_prefix():
     assert not variant.is_indel
     assert not variant.is_insertion
     assert not variant.is_deletion
-    assert variant.preserves_reading_frame
-
 
 def test_deletion_shared_suffix():
     variant = Variant(1, start=10, ref="AAC", alt="C")
@@ -110,8 +106,6 @@ def test_deletion_shared_suffix():
     assert variant.is_indel
     assert not variant.is_insertion
     assert variant.is_deletion
-    assert not variant.preserves_reading_frame
-
 
 def test_deletion_no_suffix():
     variant = Variant(1, start=10, ref="AA", alt="")
@@ -127,7 +121,6 @@ def test_deletion_no_suffix():
     assert variant.is_indel
     assert not variant.is_insertion
     assert variant.is_deletion
-    assert not variant.preserves_reading_frame
 
 def test_serialization():
     variants = [

--- a/test/test_variant_collection.py
+++ b/test/test_variant_collection.py
@@ -31,7 +31,7 @@ def test_reference_names():
 
 def test_to_string():
     string_repr = str(ov_wustle_variants)
-    assert "start=10238758, ref=G, alt=C" in string_repr, \
+    assert "start=10238758, ref='G', alt='C'" in string_repr, \
         "Expected variant g.10238758 G>C in __str__:\n%s" % (
             string_repr,)
 
@@ -40,7 +40,7 @@ def test_detailed_string():
     # expect one of the gene names from the MAF to be in the summary string
     assert "UBE4B" in detailed_string, \
         "Expected gene name UBE4B in detailed_string():\n%s" % detailed_string
-    assert "start=10238758, ref=G, alt=C" in detailed_string, \
+    assert "start=10238758, ref='G', alt='C'" in detailed_string, \
         "Expected variant g.10238758 G>C in detailed_string():\n%s" % (
             detailed_string,)
 

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -711,11 +711,3 @@ class Variant(object):
     def is_indel(self):
         """Is this variant either an insertion or deletion?"""
         return self.is_insertion or self.is_deletion
-
-    @property
-    def preserves_reading_frame(self):
-        """
-        If this variant occurs in the coding region of a gene, would it
-        prerseve the ORF or create a frameshift mutation?
-        """
-        return (len(self.alt) - len(self.ref)) % 3 == 0

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -180,7 +180,7 @@ class Variant(object):
         return self.ensembl.reference_name
 
     def __str__(self):
-        return "Variant(contig=%s, start=%d, ref='%s', alt='%s', reference_name='%s')" % (
+        return "Variant(contig='%s', start=%d, ref='%s', alt='%s', reference_name='%s')" % (
             self.contig,
             self.start,
             self.ref,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -180,11 +180,11 @@ class Variant(object):
         return self.ensembl.reference_name
 
     def __str__(self):
-        return "Variant(contig=%s, start=%d, ref=%s, alt=%s, reference_name=%s)" % (
+        return "Variant(contig=%s, start=%d, ref='%s', alt='%s', reference_name='%s')" % (
             self.contig,
             self.start,
-            self.ref if self.ref else ".",
-            self.alt if self.alt else ".",
+            self.ref,
+            self.alt,
             self.reference_name)
 
     def __repr__(self):


### PR DESCRIPTION
Instead of representing empty strings with `.`, instead using single quotes around all string fields of a `Variant`. This brings us closer to having a string representation of a variant which can be evaluated by Python to get back to the same object (the reference name isn't quite there). 

Also, got rid of `Variant.preserves_reading_frame` since I've come around to @arahuja's opinion that this is a confusing property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/139)
<!-- Reviewable:end -->
