### PR TITLE
Parse and expose sample info, including for multisample VCFs

### DIFF
--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -78,7 +78,8 @@ def test_pandas_and_pyvcf_implementations_equivalent():
         {'path': data_path("multiallelic.vcf")},
         {'path': data_path("mutect-example.vcf")},
         {'path': data_path("strelka-example.vcf")},
-        {'path': data_path("mutect-example-headerless.vcf"), 'genome': cached_release(75)},
+        {'path': data_path("mutect-example-headerless.vcf"),
+            'genome': cached_release(75)},
     ]
     if RUN_TESTS_REQUIRING_INTERNET:
         paths.append({'path': VCF_EXTERNAL_URL})
@@ -135,3 +136,12 @@ def test_multiple_alleles_per_line():
         Variant(1, 1431105, "A", "G", ensembl=ensembl),
     ]
     eq_(set(variant_list), set(expected_variants))
+
+def test_sample_info_genotype():
+    variants = load_vcf(data_path("multiallelic.vcf"))
+    assert len(variants) == 2, "Expected 2 variants but got %s" % variants
+    eq_(variants.metadata[variants[0]]['sample_info']['metastasis']['GT'],
+        '0/1')
+    eq_(variants.metadata[variants[1]]['sample_info']['metastasis']['GT'],
+        '0/1')
+

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -55,8 +55,8 @@ def load_vcf(
 
     genome : {pyensembl.Genome, reference name, Ensembl version int}, optional
         Optionally pass in a PyEnsembl Genome object, name of reference, or
-        PyEnsembl release version to specify the reference associated with a VCF
-        (otherwise infer reference from VCF using reference_vcf_key)
+        PyEnsembl release version to specify the reference associated with a
+        VCF (otherwise infer reference from VCF using reference_vcf_key)
 
     reference_vcf_key : str, optional
         Name of metadata field which contains path to reference FASTA
@@ -86,6 +86,7 @@ def load_vcf(
         for record in handle.vcf_reader:
             if only_passing and record.FILTER and record.FILTER != "PASS":
                 continue
+            info = sample_info = None
             for (alt_num, alt) in enumerate(record.ALT):
                 # We ignore "no-call" variants, i.e. those where X.ALT = [None]
                 if not alt:
@@ -98,12 +99,19 @@ def load_vcf(
                     ensembl=genome,
                     allow_extended_nucleotides=allow_extended_nucleotides)
                 variants.append(variant)
+                if info is None:
+                    info = dict(record.INFO)
+                if sample_info is None:
+                    sample_info = pyvcf_calls_to_sample_info_list(
+                        record.samples)
+
                 metadata[variant] = {
                     "id": record.ID,
                     "qual": record.QUAL,
                     "filter": record.FILTER,
                     "alt_allele_index": alt_num,
-                    "info": dict(record.INFO),
+                    "info": info,
+                    "sample_info": sample_info,
                 }
                 if max_variants and len(variants) > max_variants:
                     raise StopIteration
@@ -160,8 +168,8 @@ def load_vcf_fast(
         Allow characters other that A,C,T,G in the ref and alt strings.
 
     include_info : boolean, default True
-        Whether to parse the info column. If you don't need that column, set to
-        False for faster parsing.
+        Whether to parse the INFO and per-sample columns. If you don't need
+        these, set to False for faster parsing.
 
     chunk_size: int, optional
         Number of records to load in memory at once.
@@ -203,24 +211,53 @@ def load_vcf_fast(
         reference_vcf_key)
 
     df_iterator = read_vcf_into_dataframe(
-        path, include_info=include_info, chunk_size=chunk_size)
+        path,
+        include_info=include_info,
+        sample_names=handle.vcf_reader.samples if include_info else None,
+        chunk_size=chunk_size)
+
+    if include_info:
+        def sample_info_parser(unparsed_sample_info_strings, format_string):
+            """
+            Given a format string like "GT:AD:ADP:DP:FS"
+            and a list of sample info strings where each entry is like
+            "0/1:3,22:T=3,G=22:25:33", return a dict that maps:
+            sample name -> field name -> value. Uses pyvcf to parse the fields.
+            """
+            return pyvcf_calls_to_sample_info_list(
+                handle.vcf_reader._parse_samples(
+                    unparsed_sample_info_strings, format_string, None))
+    else:
+        sample_info_parser = None
 
     return dataframes_to_variant_collection(
         df_iterator,
         info_parser=handle.vcf_reader._parse_info if include_info else None,
         only_passing=only_passing,
         max_variants=max_variants,
+        sample_names=handle.vcf_reader.samples if include_info else None,
+        sample_info_parser=sample_info_parser,
         variant_kwargs={
             'ensembl': genome,
             'allow_extended_nucleotides': allow_extended_nucleotides},
         variant_collection_kwargs={"path": path})
 
+def pyvcf_calls_to_sample_info_list(calls):
+    """
+    Given pyvcf.model._Call instances, return a dict mapping each sample
+    name to its per-sample info:
+        sample name -> field -> value
+    """
+    return collections.OrderedDict(
+        (call.sample, call.data._asdict()) for call in calls)
 
 def dataframes_to_variant_collection(
         dataframes,
         info_parser=None,
         only_passing=True,
         max_variants=None,
+        sample_names=None,
+        sample_info_parser=None,
         variant_kwargs={},
         variant_collection_kwargs={}):
     """
@@ -248,6 +285,14 @@ def dataframes_to_variant_collection(
     max_variants : int, optional
         If specified, return only the first max_variants variants.
 
+    sample_names : list of strings, optional
+        Sample names. The final columns of the dataframe should match these.
+        If specified, the per-sample info columns will be parsed. You must
+        also specify sample_info_parser.
+
+    sample_info_parser : string list * string -> dict, optional
+        Callable to parse per-sample info columns.
+
     variant_kwargs : dict, optional
         Additional keyword paramters to pass to Variant.__init__
 
@@ -258,6 +303,13 @@ def dataframes_to_variant_collection(
     expected_columns = (
         ["CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER"] +
         (["INFO"] if info_parser else []))
+
+    if info_parser and sample_names:
+        if sample_info_parser is None:
+            raise TypeError("Must specify sample_info_parser if specifying "
+                "sample_names")
+        expected_columns.append("FORMAT")
+        expected_columns.extend(sample_names)
 
     variants = []
     metadata = {}
@@ -281,12 +333,18 @@ def dataframes_to_variant_collection(
                     id_ = None
                 qual = float(qual) if qual != "." else None
                 alt_num = 0
-                info = None
+                info = sample_info = None
                 for alt in alts.split(","):
                     if alt != ".":
                         if info_parser is not None and info is None:
-                            # tpl[-1] is info.
-                            info = info_parser(tpl[-1])
+                            info = info_parser(tpl[8])  # INFO column
+                            if sample_names:
+                                # Sample name -> field -> value dict.
+                                sample_info = sample_info_parser(
+                                    tpl[10:],  # sample info columns
+                                    tpl[9],    # FORMAT column
+                                )
+
                         variant = Variant(
                             chrom,
                             int(pos),  # want a Python int not numpy.int64
@@ -299,6 +357,7 @@ def dataframes_to_variant_collection(
                             'qual': qual,
                             'filter': flter,
                             'info': info,
+                            'sample_info': sample_info,
                             'alt_allele_index': alt_num,
                         }
                         if max_variants and len(variants) > max_variants:
@@ -311,7 +370,11 @@ def dataframes_to_variant_collection(
         variants=variants, metadata=metadata, **variant_collection_kwargs)
 
 
-def read_vcf_into_dataframe(path, include_info=False, chunk_size=None):
+def read_vcf_into_dataframe(
+        path,
+        include_info=False,
+        sample_names=None,
+        chunk_size=None):
     """
     Load the data of a VCF into a pandas dataframe. All headers are ignored.
 
@@ -323,6 +386,11 @@ def read_vcf_into_dataframe(path, include_info=False, chunk_size=None):
     include_info : boolean, default False
         If true, the INFO field is not parsed, but is included as a string in
         the resulting data frame. If false, the INFO field is omitted.
+
+    sample_names: string list, optional
+        Sample names. The final columns of the dataframe should match these.
+        If specified (and include_info is also specified), the FORMAT and
+        per-sample info columns will be included in the result dataframe.
 
     chunk_size : int, optional
         If buffering is desired, the number of rows per chunk.
@@ -343,6 +411,10 @@ def read_vcf_into_dataframe(path, include_info=False, chunk_size=None):
     vcf_field_types['FILTER'] = str
     if include_info:
         vcf_field_types['INFO'] = str
+        if sample_names:
+            vcf_field_types['FORMAT'] = str
+            for name in sample_names:
+                vcf_field_types[name] = str
 
     parsed_path = parse_url_or_path(path)
     if not parsed_path.scheme or parsed_path.scheme.lower() == "file":


### PR DESCRIPTION
Add per-sample info to vcf loading. Works the same whether you use `load_vcf`
or `load_vcf_fast`.

The VariantCollection.metadata entry for each variant now includes a
`sample_info` entry, which maps samples names to a dict of pyvcf-parsed
per-sample attributes for that sample.

I think this takes care of the "support multisample vcf" issues. Summary is:

 * a `VariantCollection` is multisample: it contains whatever variants were in your VCF
 * the `VariantCollection.metadata` dict includes per-sample info (as well as across-sample info from the INFO column and filters, etc.)
 * if you care about what sample a variant was "called" in, it is left to the user to look at the genotype and decide what to do. For most VCFs this will be available in `VariantCollection.metadata[variant]['sample_info']['GT']` and the value '0/0' means no-call and anything else means there was a call. We don't assume anything about this field here though (similarly to pyvcf).

Closes #96 . Closes #30 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/145)
<!-- Reviewable:end -->
