### PR TITLE
Fix variant pickling

### DIFF
--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -142,6 +142,9 @@ def test_serialization():
         eq_(original.alt, reconstituted.alt)
         eq_(original.start, reconstituted.start)
         eq_(original.end, reconstituted.end)
+        eq_(original.original_ref, reconstituted.original_ref)
+        eq_(original.original_alt, reconstituted.original_alt)
+        eq_(original.original_start, reconstituted.original_start)
 
         # Test json.
         serialized = original.to_json()

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -49,7 +49,7 @@ from .effects import (
     ExonLoss,
 )
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 __all__ = [
     # basic classes


### PR DESCRIPTION
Pickle the original `ref`/`alt`/`start` vs. the normalized values. This allows for all to be present in the reconstituted object.

This is related to, but shouldn't need to wait for, https://github.com/hammerlab/varcode/issues/142

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/146)
<!-- Reviewable:end -->
