### PR TITLE
Fix pyvcf error from passing _parse_samples a tuple instead of a list

### DIFF
--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -341,7 +341,7 @@ def dataframes_to_variant_collection(
                             if sample_names:
                                 # Sample name -> field -> value dict.
                                 sample_info = sample_info_parser(
-                                    tpl[10:],  # sample info columns
+                                    list(tpl[10:]),  # sample info columns
                                     tpl[9],    # FORMAT column
                                 )
 


### PR DESCRIPTION
was hitting this weird error in varlens' travis https://travis-ci.org/hammerlab/varlens/jobs/127125131 and I'm hoping this trivial change to varcode fixes it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/148)
<!-- Reviewable:end -->
