### PR TITLE
Add as_dataframe to EffectCollection

### DIFF
--- a/test/test_effect_collection.py
+++ b/test/test_effect_collection.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test properties of EffectCollection
+"""
+
+from nose.tools import eq_
+
+from .data import tcga_ov_variants
+tcga_ov_effects = tcga_ov_variants.effects()
+
+def test_to_dataframe():
+    df = tcga_ov_effects.to_dataframe()
+    eq_(len(tcga_ov_effects), len(df))

--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -166,3 +166,17 @@ def test_chromosome_normalization():
     # trimming of 'chr' prefix from hg19
     eq_(Variant("chr1", 1, "A", "G").contig, "1")
     eq_(Variant("chr1", 1, "A", "G", normalize_contig_name=False).contig, "chr1")
+
+def test_snv_transition_transversion():
+    ref_variant = Variant(1, start=100, ref="C", alt="C")
+    assert not ref_variant.is_snv
+
+    variant = Variant(1, start=100, ref="C", alt="T")
+    assert variant.is_snv
+    assert variant.is_transition
+    assert not variant.is_transversion
+
+    transversion = Variant(1, start=100, ref="C", alt="A")
+    assert transversion.is_snv
+    assert not transversion.is_transition
+    assert transversion.is_transversion

--- a/varcode/effect_collection.py
+++ b/varcode/effect_collection.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 from collections import Counter, OrderedDict
+import pandas as pd
 
 from typechecks import require_iterable_of
 
@@ -262,3 +263,26 @@ class EffectCollection(Collection):
         for effect in self:
             counter[effect.gene_name] += 1
         return counter
+
+    def to_dataframe(self):
+        """Build a dataframe from the effect collection"""
+        def row_from_effect(effect):
+            row = {}
+            row['chr'] = effect.variant.contig
+            row['position'] = effect.variant.start
+            row['ref'] = effect.variant.ref
+            row['alt'] = effect.variant.alt
+            row['gene_id'] = effect.gene_id
+            row['gene_name'] = effect.gene_name
+            row['transcript_id'] = effect.transcript_id
+            row['transcript_name'] = effect.transcript_name
+            row['variant'] = str(effect.variant)
+            row['is_snv'] = effect.variant.is_snv
+            row['is_indel'] = effect.variant.is_indel
+            row['is_transversion'] = effect.variant.is_transversion
+            row['is_transition'] = effect.variant.is_transition
+            row['effect'] = str(effect)
+            row['effect_type'] = effect.__class__.__name__
+            row['effect_description'] = effect.short_description
+            return row
+        return pd.DataFrame.from_records([row_from_effect(effect) for effect in self])

--- a/varcode/effect_collection.py
+++ b/varcode/effect_collection.py
@@ -268,8 +268,8 @@ class EffectCollection(Collection):
         """Build a dataframe from the effect collection"""
         def row_from_effect(effect):
             row = {}
-            row['chr'] = effect.variant.contig
-            row['position'] = effect.variant.start
+            row['contig'] = effect.variant.contig
+            row['start'] = effect.variant.start
             row['ref'] = effect.variant.ref
             row['alt'] = effect.variant.alt
             row['gene_id'] = effect.gene_id

--- a/varcode/nucleotides.py
+++ b/varcode/nucleotides.py
@@ -49,6 +49,12 @@ EXTENDED_NUCLEOTIDES = {
     'N',  # any base
 }
 
+def is_purine(nucleotide, allow_extended_nucleotides=False):
+    """Is the nucleotide a purine"""
+    if not allow_extended_nucleotides and nucleotide not in STANDARD_NUCLEOTIDES:
+        raise ValueError("{} is a non-standard nucleotide, neither purine or pyrimidine".format(nucleotide))
+    return nucleotide in PURINE_NUCLEOTIDES
+
 def all_standard_nucleotides(nucleotides):
     return all(base in STANDARD_NUCLEOTIDES for base in nucleotides)
 

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -51,7 +51,11 @@ from .effects import (
     ExonLoss,
     ExonicSpliceSite,
 )
-from .nucleotides import normalize_nucleotide_string, STANDARD_NUCLEOTIDES
+from .nucleotides import (
+    normalize_nucleotide_string, 
+    STANDARD_NUCLEOTIDES,
+    is_purine
+)
 from .string_helpers import trim_shared_flanking_strings
 from .transcript_helpers import interval_offset_on_transcript
 
@@ -729,3 +733,18 @@ class Variant(object):
     def is_indel(self):
         """Is this variant either an insertion or deletion?"""
         return self.is_insertion or self.is_deletion
+
+    @property
+    def is_snv(self):
+        """Is the variant a single nucleotide variant"""
+        return (len(self.ref) == len(self.alt) == 1) and (self.ref != self.alt)  
+
+    @property
+    def is_transition(self):
+        """Is this variant and pyrimidine to pyrimidine change or purine to purine change"""
+        return self.is_snv and is_purine(self.ref) == is_purine(self.alt)
+
+    @property
+    def is_transversion(self):
+        """Is this variant a pyrimidine to purine change or vice versa"""
+        return self.is_snv and is_purine(self.ref) != is_purine(self.alt)


### PR DESCRIPTION
This adds an `as_dataframe` to EffectCollection - happy to add or rename any columns.

Also, a few helper properties to `Variant` that I have been using:
- `is_snv`
- `is_transition`
- `is_transversion`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/150)
<!-- Reviewable:end -->
