### PR TITLE
Added unit tests for Klf6 frameshift, fix bug in frameshift translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ script:
   - pyensembl install --release 81 --species human
   # latest human Ensembl release
   - pyensembl install --release 83 --species human
-  # mouse tests written for mouse Ensembl #81
-  - pyensembl install --release 81 --species mouse
+  # mouse tests written for mouse Ensembl #83
+  - pyensembl install --release 83 --species mouse
   # now actually run the tests, generate a coverage report and run linter
   - nosetests test --with-coverage --cover-package=varcode && ./lint.sh
 after_success:

--- a/test/test_frameshift_helpers.py
+++ b/test/test_frameshift_helpers.py
@@ -1,0 +1,61 @@
+from varcode.frameshift_coding_effect import (
+    cdna_codon_sequence_after_insertion_frameshift,
+    cdna_codon_sequence_after_deletion_or_substitution_frameshift,
+)
+
+from nose.tools import eq_
+
+def test_cdna_codon_sequence_after_insertion_frameshift_before_codon():
+    # insertion: T_ATGCCCTAG
+    i, s = cdna_codon_sequence_after_insertion_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset_before_insertion=-1,
+        inserted_nucleotides="T")
+    eq_(i, 0)
+    eq_(s, "TATGCCCTAG")
+
+def test_cdna_codon_sequence_after_insertion_frameshift_in_middle_of_codon():
+    # insertion: A_T_TGCCCTAG
+    i, s = cdna_codon_sequence_after_insertion_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset_before_insertion=0,
+        inserted_nucleotides="T")
+    eq_(i, 0)
+    eq_(s, "ATTGCCCTAG")
+
+def test_cdna_codon_sequence_after_insertion_frameshift_at_end_of_codon():
+    # insertion: AT_T_GCCCTAG
+    i, s = cdna_codon_sequence_after_insertion_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset_before_insertion=1,
+        inserted_nucleotides="T")
+    eq_(i, 0)
+    eq_(s, "ATTGCCCTAG")
+
+def test_cdna_codon_sequence_after_insertion_frameshift_after_codon():
+    # insertion: AT_T_GCCCTAG
+    i, s = cdna_codon_sequence_after_insertion_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset_before_insertion=2,
+        inserted_nucleotides="T")
+    eq_(i, 1)
+    eq_(s, "TCCCTAG")
+
+def test_cdna_codon_sequence_after_deletion_or_substitution_frameshift_delA():
+    i, s = cdna_codon_sequence_after_deletion_or_substitution_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset=0,
+        ref="A",
+        alt="")
+    eq_(i, 0)
+    eq_(s, "TGCCCTAG")
+
+
+def test_cdna_codon_sequence_after_deletion_or_substitution_frameshift_AT_to_C():
+    i, s = cdna_codon_sequence_after_deletion_or_substitution_frameshift(
+        sequence_from_start_codon="ATGCCCTAG",
+        cds_offset=0,
+        ref="AT",
+        alt="C")
+    eq_(i, 0)
+    eq_(s, "CGCCCTAG")

--- a/test/test_frameshift_helpers.py
+++ b/test/test_frameshift_helpers.py
@@ -33,7 +33,7 @@ def test_cdna_codon_sequence_after_insertion_frameshift_at_end_of_codon():
     eq_(s, "ATTGCCCTAG")
 
 def test_cdna_codon_sequence_after_insertion_frameshift_after_codon():
-    # insertion: AT_T_GCCCTAG
+    # insertion: ATG_T_CCCTAG
     i, s = cdna_codon_sequence_after_insertion_frameshift(
         sequence_from_start_codon="ATGCCCTAG",
         cds_offset_before_insertion=2,

--- a/test/test_mm10_klf6_frameshift.py
+++ b/test/test_mm10_klf6_frameshift.py
@@ -1,0 +1,54 @@
+from varcode import Variant, FrameShift
+from varcode.frameshift_coding_effect import (
+    frameshift_coding_effect,
+    cdna_codon_sequence_after_insertion_frameshift,
+)
+
+from nose.tools import eq_
+
+def validate_effect_values(effect):
+    eq_(effect.__class__, FrameShift)
+    transcript = effect.transcript
+    eq_(transcript.name, "Klf6-201")
+    eq_(transcript.spliced_offset(5864876), 462)
+    eq_(effect.shifted_sequence, "GEEGGIRTEDFF")
+
+def test_mm10_Klf6_frameshift():
+    variant = Variant("chr13", 5864876, "", "G", "GRCm38")
+    effects = variant.effects()
+    eq_(len(effects), 1)
+    validate_effect_values(effects[0])
+
+def test_mm10_Klf6_frameshift_coding_effect_fn():
+    variant = Variant("chr13", 5864876, "", "G", "GRCm38")
+    eq_(len(variant.transcripts), 1)
+    t = variant.transcripts[0]
+    eq_(t.name, "Klf6-201")
+    # first start codon offset is 150
+    # mutation occurs after offset 462
+    effect = frameshift_coding_effect(
+        "",
+        "G",
+        462 - 150,
+        t.sequence[150:],
+        variant,
+        t)
+    validate_effect_values(effect)
+
+def test_mm10_Klf6_frameshift_cdna_codon_sequence():
+    variant = Variant("chr13", 5864876, "", "G", "GRCm38")
+    eq_(len(variant.transcripts), 1)
+    t = variant.transcripts[0]
+    eq_(t.name, "Klf6-201")
+    mutant_codon_index, seq_after_mutated_codon = \
+        cdna_codon_sequence_after_insertion_frameshift(
+            sequence_from_start_codon=t.sequence[150:],
+            cds_offset_before_insertion=462 - 150,
+            inserted_nucleotides="G")
+    eq_(mutant_codon_index, 104)
+    expected_sequence = t.sequence[462] + "G" + t.sequence[463:]
+
+    print("Reference sequence (first 20 bases): %s" % t.sequence[462:482])
+    print("Expected sequence (first 20 bases):  %s" % expected_sequence[:20])
+    print("Returned sequence (first 20 bases):  %s" % seq_after_mutated_codon[:20])
+    eq_(seq_after_mutated_codon, expected_sequence)

--- a/test/test_mouse.py
+++ b/test/test_mouse.py
@@ -6,21 +6,28 @@ from varcode import load_vcf, load_vcf_fast, Variant, Substitution
 from pyensembl import Genome, EnsemblRelease
 from . import data_path
 
-MOUSE_GTF_PATH = "ftp://ftp.ensembl.org/pub/release-81/gtf/mus_musculus/Mus_musculus.GRCm38.81.gtf.gz"
-MOUSE_TRANSCRIPT_FASTA_PATH = "ftp://ftp.ensembl.org/pub/release-81/fasta/mus_musculus/cdna/Mus_musculus.GRCm38.cdna.all.fa.gz"
-MOUSE_PROTEIN_FASTA_PATH = "ftp://ftp.ensembl.org/pub/release-81/fasta/mus_musculus/pep/Mus_musculus.GRCm38.pep.all.fa.gz"
+MOUSE_ENSEMBL_RELEASE = 83
+SERVER = "ftp://ftp.ensembl.org"
+MOUSE_GTF_PATH = \
+    SERVER + "/pub/release-%d/gtf/mus_musculus/Mus_musculus.GRCm38.%d.gtf.gz" % (
+        MOUSE_ENSEMBL_RELEASE, MOUSE_ENSEMBL_RELEASE)
+MOUSE_TRANSCRIPT_FASTA_PATH = \
+    SERVER + "/pub/release-%d/fasta/mus_musculus/cdna/Mus_musculus.GRCm38.cdna.all.fa.gz"
+MOUSE_PROTEIN_FASTA_PATH = \
+    SERVER + "/pub/release-%d/fasta/mus_musculus/pep/Mus_musculus.GRCm38.pep.all.fa.gz" % (
+        MOUSE_ENSEMBL_RELEASE)
 
 MOUSE_VCF = data_path("mouse_vcf_dbsnp_chr1_partial.vcf")
 
 explicit_url_genome = Genome(
     reference_name="GRCm38",
     annotation_name="ensembl",
-    annotation_version=81,
+    annotation_version=MOUSE_ENSEMBL_RELEASE,
     gtf_path_or_url=MOUSE_GTF_PATH,
     transcript_fasta_path_or_url=MOUSE_TRANSCRIPT_FASTA_PATH,
     protein_fasta_path_or_url=MOUSE_PROTEIN_FASTA_PATH)
 
-ensembl_mouse_genome = EnsemblRelease(81, species="mouse")
+ensembl_mouse_genome = EnsemblRelease(MOUSE_ENSEMBL_RELEASE, species="mouse")
 
 def test_load_vcf_mouse_with_explicit_urls():
     variants = load_vcf(MOUSE_VCF, genome=explicit_url_genome)

--- a/varcode/translate.py
+++ b/varcode/translate.py
@@ -17,8 +17,6 @@
 TODO: generalize this to work with the mitochondrial codon table.
 """
 
-import logging
-
 from Bio.Data import CodonTable
 from Bio.Seq import Seq
 
@@ -108,36 +106,3 @@ def translate(
                     nucleotide_sequence))
 
     return protein_sequence
-
-def transcript_protein_sequence(transcript):
-    """Get protein sequence for a transcript, translate it from the
-    coding sequence if for some reason Ensembl didn't include this transcript
-    in its FASTA of protein sequences.
-    """
-    cds_start_offset = transcript.first_start_codon_spliced_offset
-    cds_stop_offset = transcript.last_stop_codon_spliced_offset
-    cds_len = cds_stop_offset - cds_start_offset + 1
-
-    original_protein = transcript.protein_sequence
-
-    if not original_protein:
-        # Ensembl should have given us a protein sequence for every
-        # transcript but it's possible that we're trying to annotate a
-        # transcript whose biotype isn't included in the protein sequence FASTA
-        logging.warn("No protein sequence for %s in Ensembl", transcript)
-
-        original_protein = translate(
-            transcript.sequence[cds_start_offset:cds_stop_offset + 1])
-
-    # subtract 3 for the stop codon and divide by 3 since
-    # 3 nucleotides = 1 codon = 1 amino acid
-    expected_protein_length = int((cds_len - 3) / 3)
-    if len(original_protein) != expected_protein_length:
-        raise ValueError(
-            "Expected protein sequence of %s to be %d amino acids"
-            "but got %d : %s" % (
-                transcript,
-                expected_protein_length,
-                len(original_protein),
-                original_protein))
-    return original_protein


### PR DESCRIPTION
Found a scary bug in the `frameshift_coding_effect.py`. The logic for translating frameshifts was wrong for some cases, added unit tests and fix. 

Fixes https://github.com/hammerlab/varcode/issues/151, https://github.com/hammerlab/topiary/issues/52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/152)
<!-- Reviewable:end -->
