### PR TITLE
Fix versioneer prefix format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ VCS = git
 style = pep440
 versionfile_source = varcode/_version.py
 versionfile_build = varcode/_version.py
-tag_prefix = 'v'
+tag_prefix = v

--- a/varcode/_version.py
+++ b/varcode/_version.py
@@ -40,7 +40,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "None"
     cfg.versionfile_source = "varcode/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
The `cfg` syntax is tricky to get right :\ This should fix the versioneer for you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/155)
<!-- Reviewable:end -->
