### PR TITLE
Fix clone_with_new_elements for VariantCollection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ script:
   - pyensembl install --release 77 --species human
   - pyensembl install --release 81 --species human
   # latest human Ensembl release
-  - pyensembl install --release 83 --species human
+  - pyensembl install --release 84 --species human
   # mouse tests written for mouse Ensembl #83
-  - pyensembl install --release 83 --species mouse
+  - pyensembl install --release 84 --species mouse
   # now actually run the tests, generate a coverage report and run linter
   - nosetests test --with-coverage --cover-package=varcode && ./lint.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   # latest human Ensembl release
   - pyensembl install --release 84 --species human
   # mouse tests written for mouse Ensembl #83
-  - pyensembl install --release 83 --species mouse
+  - pyensembl install --release 84 --species mouse
   # now actually run the tests, generate a coverage report and run linter
   - nosetests test --with-coverage --cover-package=varcode && ./lint.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   # latest human Ensembl release
   - pyensembl install --release 84 --species human
   # mouse tests written for mouse Ensembl #83
-  - pyensembl install --release 84 --species mouse
+  - pyensembl install --release 83 --species mouse
   # now actually run the tests, generate a coverage report and run linter
   - nosetests test --with-coverage --cover-package=varcode && ./lint.sh
 after_success:

--- a/test/test_mouse.py
+++ b/test/test_mouse.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 from nose.tools import eq_
 
 from varcode import load_vcf, load_vcf_fast, Variant, Substitution
-from pyensembl import Genome, EnsemblRelease
+from pyensembl import Genome, EnsemblRelease, MAX_ENSEMBL_RELEASE
 from . import data_path
 
-MOUSE_ENSEMBL_RELEASE = 83
+MOUSE_ENSEMBL_RELEASE = MAX_ENSEMBL_RELEASE
 SERVER = "ftp://ftp.ensembl.org"
 MOUSE_GTF_PATH = \
     SERVER + "/pub/release-%d/gtf/mus_musculus/Mus_musculus.GRCm38.%d.gtf.gz" % (

--- a/varcode/collection.py
+++ b/varcode/collection.py
@@ -98,7 +98,7 @@ class Collection(object):
 
     def clone_with_new_elements(self, new_elements):
         """
-        Create another collection of the same class and  with same metadata
+        Create another collection of the same class and with same state
         but possibly different Variant or Effect entries.
         """
         return self.__class__(

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -121,6 +121,17 @@ class VariantCollection(Collection):
         joined_lines = "\n".join(lines)
         return "%s\n%s" % (header, joined_lines)
 
+    def clone_with_new_elements(self, new_elements):
+        """
+        Create another VariantCollection of the same class and with
+        same state (including metadata) but possibly different entries.
+        """
+        return self.__class__(
+            new_elements,
+            path=self.path,
+            distinct=self.distinct,
+            metadata=self.metadata)
+
     def filter_by_transcript_expression(
             self,
             transcript_expression_dict,

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -125,6 +125,10 @@ class VariantCollection(Collection):
         """
         Create another VariantCollection of the same class and with
         same state (including metadata) but possibly different entries.
+
+        Warning: metadata is a dictionary keyed by variants. This method
+        leaves that dictionary as-is, which may result in extraneous entries
+        or missing entries.
         """
         return self.__class__(
             new_elements,


### PR DESCRIPTION
Per https://github.com/hammerlab/cohorts/issues/66, we decided to use `clone_with_new_elements`; but I just realized that it wasn't actually cloning the `metadata` variable (just other "metadata").

@iskandr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/159)
<!-- Reviewable:end -->
