### PR TITLE
Fix inferred-reference-bug

### DIFF
--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nose.tools import eq_
+
+from varcode.reference import infer_reference_name, reference_alias_dict, _most_recent_assembly
+
+## test cases are given as 
+## expected response: list of inputs
+reference_test_cases = {
+    'NCBI36': ['ncbi36p2.fasta', 'b36.fasta'],
+    'GRCh38': ['grch38p2.fasta', '##reference=file:///var/lib/cwl/job367935311_index_001zdr/GRCh38.d1.vd1.fa'],
+}
+
+def test_most_recent_assembly():
+    eq_(_most_recent_assembly(['ncbi36', 'grch38']), 'grch38')
+    eq_(_most_recent_assembly(['ncbi36', 'grch38', '37mm']), 'grch38')
+    eq_(_most_recent_assembly(['ncbi36']), 'ncbi36')
+    eq_(_most_recent_assembly(['ncbi36', '35']), 'ncbi36')
+
+
+def test_infer_reference_name_aliases():
+    for assembly_name in reference_alias_dict.keys():
+        candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
+        for candidate in candidate_list:
+            eq_(infer_reference_name(candidate), assembly_name)
+
+
+def test_infer_reference_name_test_cases():
+    for assembly_name in reference_test_cases.keys():
+        candidate_list = [assembly_name] + reference_test_cases[assembly_name]
+        for candidate in candidate_list:
+            eq_(infer_reference_name(candidate), assembly_name)
+

--- a/test/test_reference.py
+++ b/test/test_reference.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 from nose.tools import eq_
-
+import warnings
 from varcode.reference import infer_reference_name, reference_alias_dict, _most_recent_assembly
 
 ## test cases are given as 
 ## expected response: list of inputs
 reference_test_cases = {
-    'NCBI36': ['ncbi36p2.fasta', 'b36.fasta'],
-    'GRCh38': ['grch38p2.fasta', '##reference=file:///var/lib/cwl/job367935311_index_001zdr/GRCh38.d1.vd1.fa'],
+    'NCBI36': ['ncbi36p2.fasta', 'b36.fasta', '##reference=file:///var/lib/cwl/ncbi36/homo_sapiens.d1.vd1.fa'],
+    'GRCh38': ['grch38p2.fasta', 
+                '##reference=file:///var/lib/cwl/job367935311_index_001zdr/GRCh38.d1.vd1.fa',
+                '##reference=file:///var/lib/cwl/job367935311_index_001zdr/GRCh38.job36.d1.vd1.fa',
+                ],
 }
 
 def test_most_recent_assembly():
@@ -31,15 +34,17 @@ def test_most_recent_assembly():
 
 
 def test_infer_reference_name_aliases():
-    for assembly_name in reference_alias_dict.keys():
-        candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
-        for candidate in candidate_list:
-            eq_(infer_reference_name(candidate), assembly_name)
+    with warnings.catch_warnings(record=True) as w:
+        for assembly_name in reference_alias_dict.keys():
+            candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
+            for candidate in candidate_list:
+                eq_(infer_reference_name(candidate), assembly_name)
 
 
 def test_infer_reference_name_test_cases():
-    for assembly_name in reference_test_cases.keys():
-        candidate_list = [assembly_name] + reference_test_cases[assembly_name]
-        for candidate in candidate_list:
-            eq_(infer_reference_name(candidate), assembly_name)
+    with warnings.catch_warnings(record=True) as w:
+        for assembly_name in reference_test_cases.keys():
+            candidate_list = [assembly_name] + reference_test_cases[assembly_name]
+            for candidate in candidate_list:
+                eq_(infer_reference_name(candidate), assembly_name)
 

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -68,24 +68,22 @@ def infer_reference_name(reference_name_or_path):
                 matches['file_name'].append(assembly_name)
             elif candidate.lower() in reference_name_or_path.lower():
                 matches['full_path'].append(assembly_name)
+
     # given set of existing matches, choose one to return
     # (first select based on file_name, then full path. If multiples, use most recent)
     if len(matches['file_name']) == 1:
         match = matches['file_name'][0]
     elif len(matches['file_name']) > 1:
         # separate logic for >1 vs 1 to give informative warning
-        most_recent = _most_recent_assembly(matches['file_name'])
-        warn('More than one reference matches path in header ({path});' +
-            ' the most recent one ({selected}) was used.'.format(
-                path=reference_file_name, selected=most_recent))
-        match = most_recent
+        match = _most_recent_assembly(matches['file_name'])
+        warn('More than one reference ({}) matches path in header ({});' \
+            .format(','.join(matches['file_name']), reference_file_name) +
+            ' the most recent one ({}) was used.'.format(match))
     elif len(matches['full_path']) >= 1:
         # combine full-path logic since warning is the same
-        most_recent = _most_recent_assembly(matches['full_path'])
-        warn('Reference could not be matched against filename ({path});' +
-            ' using the most recent match ({selected}) against the full path.'.format(
-                path=reference_name_or_path, selected=most_recent))
-        match = most_recent
+        match = _most_recent_assembly(matches['full_path'])
+        warn('Reference could not be matched against filename ({});'.format(reference_name_or_path) +
+            ' using the most recent match ({}) against the full path.'.format(match))
     else:
         raise ValueError(
             "Failed to infer genome assembly name for %s" % reference_name_or_path)

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -78,14 +78,13 @@ def infer_reference_name(reference_name_or_path):
     elif len(matches['file_name']) > 1:
         # separate logic for >1 vs 1 to give informative warning
         match = _most_recent_assembly(matches['file_name'])
-        warn('More than one reference ({}) matches path in header ({});' \
-            .format(','.join(matches['file_name']), reference_file_name) +
-            ' the most recent one ({}) was used.'.format(match))
+        warn('More than one reference ({}) matches path in header ({}); the most recent one ({}) was used.' \
+            .format(','.join(matches['file_name']), reference_file_name, match))
     elif len(matches['full_path']) >= 1:
         # combine full-path logic since warning is the same
         match = _most_recent_assembly(matches['full_path'])
-        warn('Reference could not be matched against filename ({});'.format(reference_name_or_path) +
-            ' using the most recent match ({}) against the full path.'.format(match))
+        warn('Reference could not be matched against filename ({}); using best match against full path ({}).' \
+            .format(reference_name_or_path, match))
     else:
         raise ValueError(
             "Failed to infer genome assembly name for %s" % reference_name_or_path)

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -61,7 +61,7 @@ def infer_reference_name(reference_name_or_path):
     # identify all cases where reference name or path matches candidate aliases
     reference_file_name = os.path.basename(reference_name_or_path)
     matches = {'file_name': list(), 'full_path': list()}
-    for assembly_name in sorted(reference_alias_dict.keys(), reverse=True):
+    for assembly_name in reference_alias_dict.keys():
         candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
         for candidate in candidate_list:
             if candidate.lower() in reference_file_name.lower():

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -68,7 +68,9 @@ def infer_reference_name(reference_name_or_path):
                 matches['file_name'].append(assembly_name)
             elif candidate.lower() in reference_name_or_path.lower():
                 matches['full_path'].append(assembly_name)
-
+    # remove duplicate matches (happens due to overlapping aliases)
+    matches['file_name'] = list(set(matches['file_name']))
+    matches['full_path'] = list(set(matches['full_path']))
     # given set of existing matches, choose one to return
     # (first select based on file_name, then full path. If multiples, use most recent)
     if len(matches['file_name']) == 1:

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-import operator
 from pyensembl import (
     Genome,
     cached_release,
@@ -51,7 +50,7 @@ def infer_reference_name(reference_name_or_path):
     """
     # consider reference names in reverse alphabetical order so that
     # e.g. GRCh38 comes before GRCh37
-    for assembly_name in sorted(reference_alias_dict.keys(), reverse=True):
+    for assembly_name in sorted(reference_alias_dict.keys(), key=lambda d: reference_alias_dict[d]['sort_order'], reverse=True):
         candidate_list = [assembly_name] + reference_alias_dict[assembly_name]['aliases']
         for candidate in candidate_list:
             if candidate.lower() in reference_name_or_path.lower():

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-
+import operator
 from pyensembl import (
     Genome,
     cached_release,
@@ -25,19 +25,22 @@ from typechecks import is_string, is_integer
 # but the differences are all on chrM and unplaced contigs
 reference_alias_dict = {
     # human assemblies
-    "NCBI36": ["hg18", "B36", "NCBI36"],
-    "GRCh37": ["hg19", "B37", "NCBI37"],
-    "GRCh38": ["hg38", "B38", "NCBI38"],
+    "NCBI36": {'aliases': ["hg18", "B36", "NCBI36"],
+                'sort_order': 36},
+    "GRCh37": {'aliases': ["hg19", "B37", "NCBI37"],
+                'sort_order': 37},
+    "GRCh38": {'aliases': ["hg38", "B38", "NCBI38"],
+                'sort_order': 38},
     # mouse assemblies
-    "GRCm37": ["mm9"],
-    "GRCm38": [
+    "GRCm37": {'aliases': ["mm9"], 'sort_order': 1.37},
+    "GRCm38": {'aliases': [
         "mm10",
         "GCF_000001635.24",  # GRCm38.p4
         "GCF_000001635.23",  # GRCm38.p3
         "GCF_000001635.22",  # GRCm38.p2
         "GCF_000001635.21",  # GRCm38.p1
         "GCF_000001635.20",  # GRCm38
-    ],
+    ], 'sort_order': 1.38}
 }
 
 def infer_reference_name(reference_name_or_path):
@@ -49,7 +52,7 @@ def infer_reference_name(reference_name_or_path):
     # consider reference names in reverse alphabetical order so that
     # e.g. GRCh38 comes before GRCh37
     for assembly_name in sorted(reference_alias_dict.keys(), reverse=True):
-        candidate_list = [assembly_name] + reference_alias_dict[assembly_name]
+        candidate_list = [assembly_name] + reference_alias_dict[assembly_name]['aliases']
         for candidate in candidate_list:
             if candidate.lower() in reference_name_or_path.lower():
                 return assembly_name


### PR DESCRIPTION
See issue #181 -- reference is sometimes incorrectly attributed to NCBI36 when (for example) "b36
 is in the file path.

This PR attempts to address that by hard-coding the sort order of references to check, so that search looks for GRCh38 before GRCh37 (for example) & looks for human references before mouse references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/182)
<!-- Reviewable:end -->
