### PR TITLE
Ensure README.md is packaged

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include varcode/_version.py
+include README.md
+include LICENSE


### PR DESCRIPTION
Otherwise we see `Failed to open /tmp/easy_install-2oYKTR/varcode-0.5.1/README.md` on `pip install`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/186)
<!-- Reviewable:end -->
