### PR TITLE
Add optional_cols list to load_maf

### DIFF
--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -87,9 +87,15 @@ def load_maf_dataframe(path, nrows=None, verbose=False):
     return df
 
 
-def load_maf(path):
+def load_maf(path, optional_cols=[]):
     """
     Load reference name and Variant objects from MAF filename.
+
+    Parameters
+    ----------
+    optional_cols : list, optional
+        A list of MAF columns to include as metadata if they are present in the MAF.
+        Does not result in an error if those columns are not present.
     """
     # pylint: disable=no-member
     # pylint gets confused by read_csv inside load_maf_dataframe
@@ -150,6 +156,9 @@ def load_maf(path):
             'Tumor_Sample_Barcode': x.Tumor_Sample_Barcode,
             'Matched_Norm_Sample_Barcode': x.Matched_Norm_Sample_Barcode,
         }
+        for optional_col in optional_cols:
+            if optional_col in x:
+                metadata[variant][optional_col] = x[optional_col]
 
         variants.append(variant)
 


### PR DESCRIPTION
I'm working with MAFs, and want to grab e.g. "t_alt_count" from the metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/209)
<!-- Reviewable:end -->
