### PR TITLE
Allow user to affect the sorting of variants when loading a VCF or MAF.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ memoized_property>=1.0.2
 nose>=1.3.3
 pylint>=1.4.4
 serializable>=0.0.8
-sercol>=0.0.2
+sercol>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
             'pyvcf>=0.6.7',
             'memoized_property>=1.0.2',
             'serializable>=0.0.8',
-            'sercol>=0.0.2',
+            'sercol>=0.1.0',
         ],
         entry_points={
             'console_scripts': [

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -19,7 +19,7 @@ import pandas
 from typechecks import require_string
 
 from .reference import infer_genome
-from .variant import Variant
+from .variant import Variant, variant_ascending_position_sort_key
 from .variant_collection import VariantCollection
 
 TCGA_PATIENT_ID_LENGTH = 12
@@ -87,7 +87,8 @@ def load_maf_dataframe(path, nrows=None, verbose=False):
     return df
 
 
-def load_maf(path, optional_cols=[]):
+def load_maf(path, optional_cols=[],
+             sort_key=variant_ascending_position_sort_key):
     """
     Load reference name and Variant objects from MAF filename.
 
@@ -96,6 +97,10 @@ def load_maf(path, optional_cols=[]):
     optional_cols : list, optional
         A list of MAF columns to include as metadata if they are present in the MAF.
         Does not result in an error if those columns are not present.
+
+    sort_key : fn
+        Function which maps each element to a sorting criterion.
+        Set to None to not to sort the variants.
     """
     # pylint: disable=no-member
     # pylint gets confused by read_csv inside load_maf_dataframe
@@ -164,4 +169,5 @@ def load_maf(path, optional_cols=[]):
 
     return VariantCollection(
         variants=variants,
-        source_to_metadata_dict={path: metadata})
+        source_to_metadata_dict={path: metadata},
+        sort_key=sort_key)

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -27,7 +27,7 @@ from typechecks import require_string
 import vcf as pyvcf
 
 from .reference import infer_genome
-from .variant import Variant
+from .variant import Variant, variant_ascending_position_sort_key
 from .variant_collection import VariantCollection
 
 
@@ -42,7 +42,8 @@ def load_vcf(
         allow_extended_nucleotides=False,
         include_info=True,
         chunk_size=10 ** 5,
-        max_variants=None):
+        max_variants=None,
+        sort_key=variant_ascending_position_sort_key):
     """
     Load reference name and Variant objects from the given VCF filename.
 
@@ -86,6 +87,10 @@ def load_vcf(
 
     max_variants : int, optional
         If specified, return only the first max_variants variants.
+
+    sort_key : fn
+        Function which maps each element to a sorting criterion.
+        Set to None to not to sort the variants.
     """
 
     require_string(path, "Path or URL to VCF")
@@ -117,7 +122,8 @@ def load_vcf(
                 allow_extended_nucleotides=allow_extended_nucleotides,
                 include_info=include_info,
                 chunk_size=chunk_size,
-                max_variants=max_variants)
+                max_variants=max_variants,
+                sort_key=sort_key)
         finally:
             logger.info("Removing temporary file: %s", filename)
             os.unlink(filename)
@@ -165,7 +171,9 @@ def load_vcf(
         sample_info_parser=sample_info_parser,
         variant_kwargs={
             'ensembl': genome,
-            'allow_extended_nucleotides': allow_extended_nucleotides})
+            'allow_extended_nucleotides': allow_extended_nucleotides},
+        variant_collection_kwargs={'sort_key': sort_key})
+
 
 def load_vcf_fast(*args, **kwargs):
     """


### PR DESCRIPTION
This PR exposes `sort_key` parameter of `VariantCollection` to `load_vcf` and `load_maf` so that user can have an influence on the way how variants are sorted. The default behavior of `load_vcf` and `load_maf` doesn't change with this PR.

I do have one concern, however. In the following example, shouldn't `a==b` and `c==d` on each loop?
```
import varcode

variants = [varcode.Variant(contig='1', start=4, ref='', alt=''),
            varcode.Variant(contig='1', start=1, ref='', alt=''),
            varcode.Variant(contig='1', start=3, ref='', alt=''),
            varcode.Variant(contig='1', start=2, ref='', alt='')]

for a, b, c, d in zip(
        varcode.VariantCollection(variants=variants),
        varcode.VariantCollection(variants=variants).variants,
        varcode.VariantCollection(variants=variants, sort_key=None),
        varcode.VariantCollection(variants=variants, sort_key=None).variants):
    print("%s\n%s\n%s\n%s" % (a, b, c, d))
    print("---------------------------------")
```
Output:
```
Variant(contig='1', start=1, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=4, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=1, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=4, ref='', alt='', reference_name='GRCh38')
---------------------------------
Variant(contig='1', start=2, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=1, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=2, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=1, ref='', alt='', reference_name='GRCh38')
---------------------------------
Variant(contig='1', start=3, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=3, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=3, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=3, ref='', alt='', reference_name='GRCh38')
---------------------------------
Variant(contig='1', start=4, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=2, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=4, ref='', alt='', reference_name='GRCh38')
Variant(contig='1', start=2, ref='', alt='', reference_name='GRCh38')
---------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/218)
<!-- Reviewable:end -->
