### PR TITLE
Adding a logging statement when trimming a variant to match an exon

### DIFF
--- a/test/test_effect_classes.py
+++ b/test/test_effect_classes.py
@@ -39,7 +39,7 @@ from varcode.effects import (
     FrameShiftTruncation,
     # TODO: SpliceDonor, SpliceReceptor
 )
-from pyensembl import ensembl_grch37, cached_release
+from pyensembl import ensembl_grch37, cached_release, genome_for_reference_name
 
 from .common import expect_effect
 
@@ -598,5 +598,20 @@ def test_insertion_nonfinal_stop_gain():
         variant,
         transcript_id="ENST00000003084",
         effect_class=PrematureStop,
+        modifies_coding_sequence=True,
+        modifies_protein_sequence=True)
+
+def test_variant_ending_after_exon():
+    mouse_genome = genome_for_reference_name("grcm38")
+    variant = Variant(
+        "11",
+        106262686,
+        ref="GTGAAGG",
+        alt="",
+        ensembl=mouse_genome)
+    expect_effect(
+        variant,
+        transcript_id="ENSMUST00000021049",
+        effect_class=ExonicSpliceSite,
         modifies_coding_sequence=True,
         modifies_protein_sequence=True)

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -295,6 +295,7 @@ def exonic_transcript_effect(variant, exon, exon_number, transcript):
     if variant_start < exon.start:
         # if mutation starts before current exon then only look
         # at nucleotides which overlap the exon
+        logger.info('Mutation in variant %s starts before exon %s', variant, exon)
         assert len(genome_ref) > 0, "Unexpected insertion into intron"
         n_skip_start = exon.start - variant_start
         genome_ref = genome_ref[n_skip_start:]
@@ -306,6 +307,7 @@ def exonic_transcript_effect(variant, exon, exon_number, transcript):
     if variant_end > exon.end:
         # if mutation goes past exon end then only look at nucleotides
         # which overlap the exon
+        logger.info('Mutation in variant %s ends after exon %s', variant, exon)
         n_skip_end = variant_end - exon.end
         genome_ref = genome_ref[:-n_skip_end]
         genome_alt = genome_alt[:len(genome_ref)]


### PR DESCRIPTION
Also a test to make sure it's sane and the logging statement is printed (run with --debug=varcode).

See https://github.com/hammerlab/isovar/issues/82 for more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/varcode/225)
<!-- Reviewable:end -->
